### PR TITLE
DDT-26 Update transport event

### DIFF
--- a/src/main/java/org/dcsa/core/events/model/TransportEvent.java
+++ b/src/main/java/org/dcsa/core/events/model/TransportEvent.java
@@ -7,6 +7,9 @@ import org.springframework.data.annotation.Transient;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
+import java.util.List;
+import java.util.UUID;
+
 @Table("transport_event")
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -27,4 +30,7 @@ public class TransportEvent extends Event {
 
     @Transient
     private TransportCall transportCall;
+
+    @Transient
+    private List<Reference> references;
 }

--- a/src/main/java/org/dcsa/core/events/model/TransportEvent.java
+++ b/src/main/java/org/dcsa/core/events/model/TransportEvent.java
@@ -3,11 +3,15 @@ package org.dcsa.core.events.model;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.dcsa.core.events.model.enums.DocumentReferenceType;
+import org.dcsa.core.events.model.transferobjects.DocumentReferenceTO;
 import org.springframework.data.annotation.Transient;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Table("transport_event")
@@ -30,6 +34,9 @@ public class TransportEvent extends Event {
 
     @Transient
     private TransportCall transportCall;
+
+    @Transient
+    private List<DocumentReferenceTO> documentReferences;
 
     @Transient
     private List<Reference> references;

--- a/src/main/java/org/dcsa/core/events/model/TransportEvent.java
+++ b/src/main/java/org/dcsa/core/events/model/TransportEvent.java
@@ -3,16 +3,13 @@ package org.dcsa.core.events.model;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.dcsa.core.events.model.enums.DocumentReferenceType;
 import org.dcsa.core.events.model.transferobjects.DocumentReferenceTO;
+import org.dcsa.core.events.model.transferobjects.TransportCallTO;
 import org.springframework.data.annotation.Transient;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
-import java.util.UUID;
 
 @Table("transport_event")
 @Data
@@ -33,7 +30,7 @@ public class TransportEvent extends Event {
     private String transportCallID;
 
     @Transient
-    private TransportCall transportCall;
+    private TransportCallTO transportCall;
 
     @Transient
     private List<DocumentReferenceTO> documentReferences;

--- a/src/main/java/org/dcsa/core/events/model/enums/DocumentReferenceType.java
+++ b/src/main/java/org/dcsa/core/events/model/enums/DocumentReferenceType.java
@@ -1,0 +1,6 @@
+package org.dcsa.core.events.model.enums;
+
+public enum DocumentReferenceType {
+    BKG, // Booking
+    TRD, // Transport Document
+}

--- a/src/main/java/org/dcsa/core/events/model/transferobjects/DocumentReferenceTO.java
+++ b/src/main/java/org/dcsa/core/events/model/transferobjects/DocumentReferenceTO.java
@@ -1,0 +1,12 @@
+package org.dcsa.core.events.model.transferobjects;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.dcsa.core.events.model.enums.DocumentReferenceType;
+
+@Data
+@RequiredArgsConstructor(staticName = "of")
+public class DocumentReferenceTO {
+    private final DocumentReferenceType documentReferenceType;
+    private final String documentReferenceValue;
+}

--- a/src/main/java/org/dcsa/core/events/repository/TransportCallRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/TransportCallRepository.java
@@ -3,6 +3,7 @@ package org.dcsa.core.events.repository;
 import org.dcsa.core.events.model.TransportCall;
 import org.dcsa.core.repository.ExtendedRepository;
 import org.springframework.data.r2dbc.repository.Query;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.UUID;
@@ -13,4 +14,20 @@ public interface TransportCallRepository extends ExtendedRepository<TransportCal
             + " WHERE transport.load_transport_call_id = :transportCallID"
             + " OR transport.discharge_transport_call_id = :transportCallID")
     Mono<UUID> findShipmentIDByTransportCallID(String transportCallID);
+
+    @Query("SELECT DISTINCT shipment.carrier_booking_reference from dcsa_im_v3_0.shipment shipment"
+            + " JOIN dcsa_im_v3_0.shipment_transport shipment_transport ON shipment_transport.shipment_id = shipment.id"
+            + " JOIN dcsa_im_v3_0.transport transport ON transport.id = shipment_transport.transport_id"
+            + " WHERE transport.load_transport_call_id = :transportCallID"
+            + " OR transport.discharge_transport_call_id = :transportCallID")
+    Flux<String> findBookingReferencesByTransportCallID(String transportCallID);
+
+    @Query("SELECT DISTINCT transport_document.transport_document_reference from dcsa_im_v3_0.transport_document transport_document"
+            + " JOIN dcsa_im_v3_0.cargo_item cargo_item ON cargo_item.shipping_instruction_id = transport_document.shipping_instruction_id"
+            + " JOIN dcsa_im_v3_0.shipment_equipment shipment_equipment ON shipment_equipment.id = cargo_item.shipment_equipment_id"
+            + " JOIN dcsa_im_v3_0.shipment_transport shipment_transport ON shipment_transport.shipment_id = shipment_equipment.shipment_id"
+            + " JOIN dcsa_im_v3_0.transport transport ON transport.id = shipment_transport.transport_id"
+            + " WHERE transport.load_transport_call_id = :transportCallID"
+            + " OR transport.discharge_transport_call_id = :transportCallID")
+    Flux<String> findTransportDocumentReferencesByTransportCallID(String transportCallID);
 }

--- a/src/main/java/org/dcsa/core/events/repository/TransportCallRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/TransportCallRepository.java
@@ -2,7 +2,15 @@ package org.dcsa.core.events.repository;
 
 import org.dcsa.core.events.model.TransportCall;
 import org.dcsa.core.repository.ExtendedRepository;
+import org.springframework.data.r2dbc.repository.Query;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
 
 public interface TransportCallRepository extends ExtendedRepository<TransportCall, String> {
-
+    @Query("SELECT DISTINCT shipment_transport.shipment_id from shipment_transport shipment_transport"
+            + " JOIN transport transport ON transport.id = shipment_transport.transport_id"
+            + " WHERE transport.load_transport_call_id = :transportCallID"
+            + " OR transport.discharge_transport_call_id = :transportCallID")
+    Mono<UUID> findShipmentIDByTransportCallID(String transportCallID);
 }

--- a/src/main/java/org/dcsa/core/events/repository/TransportCallTORepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/TransportCallTORepository.java
@@ -1,0 +1,7 @@
+package org.dcsa.core.events.repository;
+
+import org.dcsa.core.events.model.transferobjects.TransportCallTO;
+import org.dcsa.core.repository.ExtendedRepository;
+
+public interface TransportCallTORepository extends ExtendedRepository<TransportCallTO, String> {
+}

--- a/src/main/java/org/dcsa/core/events/service/TransportCallTOService.java
+++ b/src/main/java/org/dcsa/core/events/service/TransportCallTOService.java
@@ -1,0 +1,8 @@
+package org.dcsa.core.events.service;
+
+import org.dcsa.core.events.model.transferobjects.TransportCallTO;
+import org.dcsa.core.service.BaseService;
+
+public interface TransportCallTOService extends BaseService<TransportCallTO, String> {
+
+}

--- a/src/main/java/org/dcsa/core/events/service/TransportEventService.java
+++ b/src/main/java/org/dcsa/core/events/service/TransportEventService.java
@@ -8,4 +8,6 @@ public interface TransportEventService extends EventService<TransportEvent> {
     Flux<TransportEvent> mapTransportCall(Flux<TransportEvent> transportEvents);
 
     Mono<TransportEvent> mapReferences(TransportEvent transportEvents);
+
+    Mono<TransportEvent> mapDocumentReferences(TransportEvent transportEvent);
 }

--- a/src/main/java/org/dcsa/core/events/service/TransportEventService.java
+++ b/src/main/java/org/dcsa/core/events/service/TransportEventService.java
@@ -1,13 +1,12 @@
 package org.dcsa.core.events.service;
 
 import org.dcsa.core.events.model.TransportEvent;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface TransportEventService extends EventService<TransportEvent> {
-    Flux<TransportEvent> mapTransportCall(Flux<TransportEvent> transportEvents);
+    Mono<TransportEvent> mapTransportCall(TransportEvent transportEvent);
 
-    Mono<TransportEvent> mapReferences(TransportEvent transportEvents);
+    Mono<TransportEvent> mapReferences(TransportEvent transportEvent);
 
     Mono<TransportEvent> mapDocumentReferences(TransportEvent transportEvent);
 }

--- a/src/main/java/org/dcsa/core/events/service/TransportEventService.java
+++ b/src/main/java/org/dcsa/core/events/service/TransportEventService.java
@@ -2,7 +2,10 @@ package org.dcsa.core.events.service;
 
 import org.dcsa.core.events.model.TransportEvent;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 public interface TransportEventService extends EventService<TransportEvent> {
     Flux<TransportEvent> mapTransportCall(Flux<TransportEvent> transportEvents);
+
+    Mono<TransportEvent> mapReferences(TransportEvent transportEvents);
 }

--- a/src/main/java/org/dcsa/core/events/service/impl/GenericEventServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/GenericEventServiceImpl.java
@@ -46,6 +46,7 @@ public class GenericEventServiceImpl extends ExtendedBaseServiceImpl<EventReposi
         Flux<TransportEvent> transportEvents = events
                 .filter(event -> event.getEventType() == EventType.TRANSPORT)
                 .map(event -> (TransportEvent) event)
+                .flatMap(transportEventService::mapTransportCall)
                 .flatMap(transportEventService::mapReferences)
                 .flatMap(transportEventService::mapDocumentReferences);
 

--- a/src/main/java/org/dcsa/core/events/service/impl/GenericEventServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/GenericEventServiceImpl.java
@@ -4,8 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.dcsa.core.events.model.*;
 import org.dcsa.core.events.model.enums.EventType;
 import org.dcsa.core.events.repository.EventRepository;
-import org.dcsa.core.events.repository.ReferenceRepository;
-import org.dcsa.core.events.repository.TransportCallRepository;
 import org.dcsa.core.events.service.EquipmentEventService;
 import org.dcsa.core.events.service.GenericEventService;
 import org.dcsa.core.events.service.ShipmentEventService;
@@ -48,7 +46,8 @@ public class GenericEventServiceImpl extends ExtendedBaseServiceImpl<EventReposi
         Flux<TransportEvent> transportEvents = events
                 .filter(event -> event.getEventType() == EventType.TRANSPORT)
                 .map(event -> (TransportEvent) event)
-                .flatMap(transportEventService::mapReferences);
+                .flatMap(transportEventService::mapReferences)
+                .flatMap(transportEventService::mapDocumentReferences);
 
         Flux<ShipmentEvent> shipmentEvents = events
                 .filter(event -> event.getEventType() == EventType.SHIPMENT)

--- a/src/main/java/org/dcsa/core/events/service/impl/TransportCallTOServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/TransportCallTOServiceImpl.java
@@ -1,0 +1,19 @@
+package org.dcsa.core.events.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.dcsa.core.events.model.transferobjects.TransportCallTO;
+import org.dcsa.core.events.repository.TransportCallTORepository;
+import org.dcsa.core.events.service.TransportCallTOService;
+import org.dcsa.core.service.impl.ExtendedBaseServiceImpl;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class TransportCallTOServiceImpl extends ExtendedBaseServiceImpl<TransportCallTORepository, TransportCallTO, String> implements TransportCallTOService {
+    private final TransportCallTORepository transportCallTORepository;
+
+    @Override
+    public TransportCallTORepository getRepository() {
+        return transportCallTORepository;
+    }
+}

--- a/src/main/java/org/dcsa/core/events/service/impl/TransportEventServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/TransportEventServiceImpl.java
@@ -8,6 +8,7 @@ import org.dcsa.core.events.model.transferobjects.DocumentReferenceTO;
 import org.dcsa.core.events.repository.ReferenceRepository;
 import org.dcsa.core.events.repository.TransportCallRepository;
 import org.dcsa.core.events.service.TransportCallService;
+import org.dcsa.core.events.service.TransportCallTOService;
 import org.dcsa.core.service.impl.ExtendedBaseServiceImpl;
 import org.dcsa.core.events.repository.TransportEventRepository;
 import org.dcsa.core.events.service.TransportEventService;
@@ -28,6 +29,9 @@ public class TransportEventServiceImpl extends ExtendedBaseServiceImpl<Transport
     private TransportCallRepository transportCallRepository;
 
     @Autowired
+    private TransportCallTOService transportCallTOService;
+
+    @Autowired
     private ReferenceRepository referenceRepository;
 
 
@@ -43,16 +47,17 @@ public class TransportEventServiceImpl extends ExtendedBaseServiceImpl<Transport
     }
 
     @Override
-    public Flux<TransportEvent> mapTransportCall(Flux<TransportEvent> transportEvents){
-        return transportEvents
-                .flatMap(transportEvent ->
-                        transportCallService.findById(transportEvent.getTransportCallID())
-                                .doOnNext(transportEvent::setTransportCall)
-                                .thenReturn(transportEvent));
+    public Mono<TransportEvent> mapTransportCall(TransportEvent transportEvent){
+        return transportCallTOService
+                .findById(transportEvent.getTransportCallID())
+                .doOnNext(transportEvent::setTransportCall)
+                .thenReturn(transportEvent);
     }
 
     @Override
     public Mono<TransportEvent> mapReferences(TransportEvent transportEvent) {
+        // FIXME: Remove comment after test
+        // Flux<Reference> references = transportCallRepository.findShipmentIDByTransportCallID("770b7624-403d-11eb-b44b-d3f4ad185387")
         Flux<Reference> references = transportCallRepository
                 .findShipmentIDByTransportCallID(transportEvent.getTransportCallID())
                 .flatMapMany(referenceRepository::findByShipmentID);

--- a/src/main/java/org/dcsa/core/events/service/impl/TransportEventServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/TransportEventServiceImpl.java
@@ -1,11 +1,15 @@
 package org.dcsa.core.events.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.dcsa.core.events.model.Reference;
 import org.dcsa.core.events.model.TransportEvent;
+import org.dcsa.core.events.repository.ReferenceRepository;
+import org.dcsa.core.events.repository.TransportCallRepository;
 import org.dcsa.core.events.service.TransportCallService;
 import org.dcsa.core.service.impl.ExtendedBaseServiceImpl;
 import org.dcsa.core.events.repository.TransportEventRepository;
 import org.dcsa.core.events.service.TransportEventService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -17,6 +21,12 @@ import java.util.UUID;
 public class TransportEventServiceImpl extends ExtendedBaseServiceImpl<TransportEventRepository, TransportEvent, UUID> implements TransportEventService {
     private final TransportEventRepository transportEventRepository;
     private final TransportCallService transportCallService;
+
+    @Autowired
+    private TransportCallRepository transportCallRepository;
+
+    @Autowired
+    private ReferenceRepository referenceRepository;
 
 
     @Override
@@ -37,5 +47,15 @@ public class TransportEventServiceImpl extends ExtendedBaseServiceImpl<Transport
                         transportCallService.findById(transportEvent.getTransportCallID())
                                 .doOnNext(transportEvent::setTransportCall)
                                 .thenReturn(transportEvent));
+    }
+
+    @Override
+    public Mono<TransportEvent> mapReferences(TransportEvent transportEvent) {
+        Flux<Reference> references = transportCallRepository
+                .findShipmentIDByTransportCallID(transportEvent.getTransportCallID())
+                .flatMapMany(referenceRepository::findByShipmentID);
+        return references.collectList()
+                .doOnNext(transportEvent::setReferences)
+                .thenReturn(transportEvent);
     }
 }

--- a/src/main/java/org/dcsa/core/events/service/impl/TransportEventServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/TransportEventServiceImpl.java
@@ -56,8 +56,6 @@ public class TransportEventServiceImpl extends ExtendedBaseServiceImpl<Transport
 
     @Override
     public Mono<TransportEvent> mapReferences(TransportEvent transportEvent) {
-        // FIXME: Remove comment after test
-        // Flux<Reference> references = transportCallRepository.findShipmentIDByTransportCallID("770b7624-403d-11eb-b44b-d3f4ad185387")
         Flux<Reference> references = transportCallRepository
                 .findShipmentIDByTransportCallID(transportEvent.getTransportCallID())
                 .flatMapMany(referenceRepository::findByShipmentID);


### PR DESCRIPTION
Update transport event to include references, document references and basic transport call (TransportCallTO - missing vessel etc.).