### PR TITLE
Mark GenericEventServiceImpl as primary

### DIFF
--- a/src/main/java/org/dcsa/core/events/service/impl/GenericEventServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/GenericEventServiceImpl.java
@@ -14,6 +14,7 @@ import org.dcsa.core.exception.NotFoundException;
 import org.dcsa.core.extendedrequest.ExtendedRequest;
 import org.dcsa.core.service.impl.ExtendedBaseServiceImpl;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -22,17 +23,15 @@ import java.util.UUID;
 
 @RequiredArgsConstructor
 @Service
+@Primary
 public class GenericEventServiceImpl extends ExtendedBaseServiceImpl<EventRepository, Event, UUID> implements GenericEventService {
 
     @Autowired
     private ShipmentEventService shipmentEventService;
-
     @Autowired
     private TransportEventService transportEventService;
-
     @Autowired
     private EquipmentEventService equipmentEventService;
-
     @Autowired
     private EventRepository eventRepository;
 

--- a/src/main/java/org/dcsa/core/events/service/impl/TransportEventServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/TransportEventServiceImpl.java
@@ -35,15 +35,15 @@ public class TransportEventServiceImpl extends ExtendedBaseServiceImpl<Transport
         return mapTransportCall(event)
                 .flatMap(transportEvent ->
                         transportCallService.findReferencesForTransportCallID(event.getTransportCallID())
-                            .doOnNext(transportEvent::setReferences)
-                            .then(transportCallService.findDocumentReferencesForTransportCallID(event.getTransportCallID()))
-                            .doOnNext(transportEvent::setDocumentReferences)
-                            .thenReturn(transportEvent)
+                                .doOnNext(transportEvent::setReferences)
+                                .then(transportCallService.findDocumentReferencesForTransportCallID(event.getTransportCallID()))
+                                .doOnNext(transportEvent::setDocumentReferences)
+                                .thenReturn(transportEvent)
                 );
     }
 
     @Override
-    public Mono<TransportEvent> mapTransportCall(TransportEvent transportEvent){
+    public Mono<TransportEvent> mapTransportCall(TransportEvent transportEvent) {
         return transportCallTOService
                 .findById(transportEvent.getTransportCallID())
                 .doOnNext(transportEvent::setTransportCall)


### PR DESCRIPTION
This is done to help the compiler distinguish between implementations.