### PR TITLE
Fix wrong mapping of TransportCallTO

### DIFF
--- a/src/main/java/org/dcsa/core/events/service/impl/OperationsEventServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/OperationsEventServiceImpl.java
@@ -49,7 +49,7 @@ public class OperationsEventServiceImpl extends ExtendedBaseServiceImpl<Operatio
         if (operationsEvent.getTransportCallID() == null) return Mono.empty();
         return transportCallTOService
                 .findById(operationsEvent.getTransportCallID())
-                .doOnNext(transportCall -> operationsEvent.setTransportCall(MappingUtils.instanceFrom(transportCall, TransportCallTO::new, AbstractTransportCall.class)))
+                .doOnNext(operationsEvent::setTransportCall)
                 .thenReturn(operationsEvent);
     }
     private Mono<OperationsEvent> getAndSetPublisher(OperationsEvent operationsEvent) {


### PR DESCRIPTION
transportCallTOService.findById returns a TransportCallTO object which should be used directly - no mapping needed