### PR TITLE
Enforce minimum retry-delay on error

### DIFF
--- a/src/main/java/org/dcsa/core/events/service/impl/MessageSignatureHandler.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/MessageSignatureHandler.java
@@ -467,13 +467,17 @@ public class MessageSignatureHandler {
     private long computeNextDelay(EventSubscriptionState eventSubscriptionState) {
         Long delaySeconds = eventSubscriptionState.getAccumulatedRetryDelay();
         long limit = messageServiceConfig.getMaxRetryAfterDelay().toSeconds();
+        long minDelay = messageServiceConfig.getMinRetryAfterDelay().toSeconds();
         if (delaySeconds == null) {
-            delaySeconds = messageServiceConfig.getMinRetryAfterDelay().toSeconds();
+            delaySeconds = minDelay;
         } else {
             delaySeconds *= 2;
         }
         if (delaySeconds >= limit) {
             delaySeconds = limit;
+        } else if (delaySeconds < minDelay) {
+            // in case someone set it the delay to 0 or something else in the database directly.
+            delaySeconds = minDelay;
         }
         return delaySeconds;
     }


### PR DESCRIPTION
If you set the `accumulated_retry_delay` to `0` rather than `NULL` in
the database, then the retry delay remains 0 forever.  To better cope
with this, we enforce the minimum delay now.

Signed-off-by: Niels Thykier <nt@asseco.dk>