### PR TITLE
Provide standardized validation for location types

### DIFF
--- a/src/main/java/org/dcsa/core/events/validator/ValidLocationSubtype.java
+++ b/src/main/java/org/dcsa/core/events/validator/ValidLocationSubtype.java
@@ -1,0 +1,106 @@
+package org.dcsa.core.events.validator;
+
+import org.dcsa.core.events.model.transferobjects.LocationTO;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Validates that a given location matches a given valid subtype
+ *
+ * Example subtypes could be a facility, a geo coordinate, or an
+ * address-based location as three distinct subtypes.
+ *
+ * The validation ensures a minimum requirement, but it does not restrict
+ * additional fields.  As an example, the {@link LocationSubtype#GEO_COORDINATE}
+ * subtype ensures that the "latitude" and "longitude" field must be non-null.
+ * However, it does not <i>forbid</i> the address field from being present as
+ * well.
+ *
+ * The annotation can be repeated to require that the location satisfies multiple
+ * location subtypes at the same time (same as logical AND) in the rare case where
+ * that is needed.
+ *
+ * Note that this does <b>not</b> ensure that the location is not null.
+ * For that, please also use @{@link javax.validation.constraints.NotNull}
+ * in addition to this annotation.
+ */
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = ValidLocationSubtypeValidator.class)
+@Repeatable(ValidLocationSubtype.List.class)
+public @interface ValidLocationSubtype {
+
+    /**
+     * List of subtypes that are valid
+     *
+     * Defaults to {@link LocationSubtype#values()} when empty.
+     */
+    LocationSubtype[] anyOf() default {};
+
+    enum LocationSubtype {
+        /**
+         * Ensures that UN Location Code is not null
+         */
+        UN_LOCATION,
+        /**
+         * Ensures that the Geo coordinate fields are set (latitude and longitude)
+         */
+        GEO_COORDINATE,
+        /**
+         * Ensures that the facility fields (facilityCode and facilityCodeListProvider) is set
+         *
+         * It may also ensure that the UN Location Code is also set (depending on the code list provider)
+         */
+        FACILITY,
+        /**
+         * Ensures that address is not null.
+         *
+         * There are no restrictions on the {@link org.dcsa.core.events.model.Address} object other
+         * than it is not null. Accordingly, you will need an additional validation if you expect
+         * particular fields set on the Address.
+         */
+        ADDRESS,
+        ;
+
+        public boolean locationMatch(LocationTO locationTO) {
+            switch (this) {
+                case UN_LOCATION:
+                    return locationTO.getUnLocationCode() != null;
+                case GEO_COORDINATE:
+                    return locationTO.getLatitude() != null && locationTO.getLongitude() != null;
+                case FACILITY:
+                    // At the moment, a facility implies a UN location code as existing facility code lists
+                    // are defined "on top" of UN location codes.  However, eventually we may get a code list
+                    // provider not defined by UN location code.  In that case this conditional should be
+                    // updated to cater for that.
+                    return locationTO.getUnLocationCode() != null && locationTO.getFacilityCode() != null && locationTO.getFacilityCodeListProvider() != null;
+                case ADDRESS:
+                    return locationTO.getAddress() != null;
+            }
+            throw new AssertionError("Unhandled enum case");
+        }
+    }
+
+    String message() default "must match one of the following location sub types: {anyOf}";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+    @Retention(RUNTIME)
+    @Documented
+    @interface List {
+        ValidLocationSubtype[] value();
+    }
+}

--- a/src/main/java/org/dcsa/core/events/validator/ValidLocationSubtypeValidator.java
+++ b/src/main/java/org/dcsa/core/events/validator/ValidLocationSubtypeValidator.java
@@ -1,0 +1,32 @@
+package org.dcsa.core.events.validator;
+
+import org.dcsa.core.events.model.transferobjects.LocationTO;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Set;
+
+public class ValidLocationSubtypeValidator implements ConstraintValidator<ValidLocationSubtype, LocationTO> {
+
+    private Set<ValidLocationSubtype.LocationSubtype> expectedSubtypes = EnumSet.allOf(ValidLocationSubtype.LocationSubtype.class);
+
+    @Override
+    public void initialize(ValidLocationSubtype constraintAnnotation) {
+        expectedSubtypes = EnumSet.copyOf(Arrays.asList(constraintAnnotation.anyOf()));
+    }
+
+    @Override
+    public boolean isValid(LocationTO value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+        for (ValidLocationSubtype.LocationSubtype subtype : this.expectedSubtypes) {
+            if (subtype.locationMatch(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/test/java/org/dcsa/core/events/validator/ValidLocationSubtypeValidatorTest.java
+++ b/src/test/java/org/dcsa/core/events/validator/ValidLocationSubtypeValidatorTest.java
@@ -1,0 +1,158 @@
+package org.dcsa.core.events.validator;
+
+import lombok.Data;
+import org.dcsa.core.events.model.Address;
+import org.dcsa.core.events.model.enums.FacilityCodeListProvider;
+import org.dcsa.core.events.model.transferobjects.LocationTO;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import java.util.Set;
+
+public class ValidLocationSubtypeValidatorTest {
+
+    private static final LocationTO GEO_COORDINATE_LOCATION = withGeoCoordinates(new LocationTO());
+    private static final LocationTO UN_LOCATION_LOCATION = withUnLocation(new LocationTO());
+    private static final LocationTO FACILITY_LOCATION = withFacility(new LocationTO());
+    private static final LocationTO ADDRESS_LOCATION = withAddress(new LocationTO());
+    private static final LocationTO ADDRESS_WITH_GEO_COORDINATE_LOCATION = withGeoCoordinates(withAddress(new LocationTO()));
+    private static final LocationTO EMPTY_LOCATION = new LocationTO();
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void beforeClass() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    void testBasicValidCases() {
+        Assertions.assertTrue(validate(LocationHolder.of(
+                GEO_COORDINATE_LOCATION,
+                UN_LOCATION_LOCATION,
+                UN_LOCATION_LOCATION,  // <-- POTE can be either UN or facility
+                FACILITY_LOCATION,
+                ADDRESS_LOCATION
+        )));
+
+        Assertions.assertTrue(validate(LocationHolder.of(
+                GEO_COORDINATE_LOCATION,
+                UN_LOCATION_LOCATION,
+                FACILITY_LOCATION,  // <-- POTE can be either UN or facility
+                FACILITY_LOCATION,
+                ADDRESS_LOCATION
+        )));
+
+        Assertions.assertTrue(validate(LocationHolder.of(
+                ADDRESS_WITH_GEO_COORDINATE_LOCATION,  // Counts as both, so it is fine
+                UN_LOCATION_LOCATION,
+                FACILITY_LOCATION,  // <-- POTE can be either UN or facility
+                FACILITY_LOCATION,
+                ADDRESS_WITH_GEO_COORDINATE_LOCATION // Counts as both, so it is fine
+        )));
+    }
+
+    @Test
+    void testBasicInvalidCases() {
+        Assertions.assertEquals(2, issueCount(LocationHolder.of(
+                UN_LOCATION_LOCATION,  // UN and Geo are swapped
+                GEO_COORDINATE_LOCATION,
+                UN_LOCATION_LOCATION,
+                FACILITY_LOCATION,
+                ADDRESS_LOCATION
+        )));
+
+        Assertions.assertEquals(1, issueCount(LocationHolder.of(
+                GEO_COORDINATE_LOCATION,
+                UN_LOCATION_LOCATION,
+                EMPTY_LOCATION,  // Does not count as a facility or a un location
+                FACILITY_LOCATION,
+                ADDRESS_LOCATION
+        )));
+    }
+
+    @Test
+    void testDoubleRestriction() {
+        Assertions.assertTrue(validate(DoubleRestriction.of(ADDRESS_WITH_GEO_COORDINATE_LOCATION)));
+        Assertions.assertEquals(1, issueCount(DoubleRestriction.of(ADDRESS_LOCATION)));
+        Assertions.assertEquals(1, issueCount(DoubleRestriction.of(GEO_COORDINATE_LOCATION)));
+    }
+
+    @Test
+    void testNull() {
+        Assertions.assertTrue(validate(DoubleRestriction.of(null)));
+    }
+
+
+    private <T> boolean validate(T value) {
+        return issueCount(value) == 0;
+    }
+
+    private <T> int issueCount(T value) {
+        Set<ConstraintViolation<T>> issues = validator.validate(value);
+        return issues.size();
+    }
+
+    private static LocationTO withGeoCoordinates(LocationTO locationTO) {
+        locationTO.setLatitude("48.8585500");
+        locationTO.setLongitude("2.294492036");
+        return locationTO;
+    }
+
+    private static LocationTO withAddress(LocationTO locationTO) {
+        Address address = new Address();
+        address.setStreet("Kronprincessegade");
+        address.setStreetNumber("54");
+        address.setFloor("5. sal");
+        address.setPostalCode("1306");
+        address.setCity("København");
+        address.setCountry("Denmark");
+        locationTO.setAddress(address);
+        return locationTO;
+    }
+
+    private static LocationTO withUnLocation(LocationTO locationTO) {
+        locationTO.setUnLocationCode("DEHAM");
+        return locationTO;
+    }
+
+    private static LocationTO withFacility(LocationTO locationTO) {
+        locationTO.setUnLocationCode("DEHAM");
+        locationTO.setFacilityCode("EGH");
+        locationTO.setFacilityCodeListProvider(FacilityCodeListProvider.SMDG);
+        return locationTO;
+    }
+
+    @Data(staticConstructor = "of")
+    private static class LocationHolder {
+        @ValidLocationSubtype(anyOf = ValidLocationSubtype.LocationSubtype.GEO_COORDINATE)
+        private final LocationTO vesselPosition;
+
+        @ValidLocationSubtype(anyOf = ValidLocationSubtype.LocationSubtype.UN_LOCATION)
+        private final LocationTO portLocation;
+
+        @ValidLocationSubtype(anyOf = {ValidLocationSubtype.LocationSubtype.FACILITY, ValidLocationSubtype.LocationSubtype.UN_LOCATION})
+        private final LocationTO poteLocation;
+
+        @ValidLocationSubtype(anyOf = ValidLocationSubtype.LocationSubtype.FACILITY)
+        private final LocationTO facilityLocation;
+
+        @ValidLocationSubtype(anyOf = ValidLocationSubtype.LocationSubtype.ADDRESS)
+        private final LocationTO addressLocation;
+    }
+
+    @Data(staticConstructor = "of")
+    private static class DoubleRestriction {
+
+        @ValidLocationSubtype(anyOf = ValidLocationSubtype.LocationSubtype.GEO_COORDINATE)
+        @ValidLocationSubtype(anyOf = ValidLocationSubtype.LocationSubtype.ADDRESS)
+        private final LocationTO geoWithAddressLocation;
+    }
+
+}


### PR DESCRIPTION
This validation is for when the API requests mandates a particular
type of location such as `addressLocation` or `facilityLocation`.  In
this case, it can be used as the following:

```java
   @ValidLocationSubtype(anyOf = {ValidLocationSubtype.LocationSubtype.ADDRESS, ValidLocationSubtype.LocationSubtype.FACILITY})
   private final LocationTO addressOrFacilityLocationType;

```

Note that the annotation provides a minimum validation and permits
other fields to be present as well.  Accordingly, a geo coordinate
with an address would count as both a `GEO_COORDINATE` and an
`ADDRESS` location at the same time and would pass the restriction
from the example.

In the rare case that `and` restrictions are needed, then the
annotation can be repeated.  It will still not prevent "additional"
fields but can be useful to ensure that you have a facility with a UN
Location Code (to future proof in case we get facility code lists that
do not depend on UN Location codes).  As an example:

```java
     // Either UN Location Code OR facility (or both)
     @ValidLocationSubtype(anyOf = {ValidLocationSubtype.LocationSubtype.UN_LOCATION, ValidLocationSubtype.LocationSubtype.FACILITY})
     private final LocationTO poteLocation;

     // UN Location code AND facility
     @ValidLocationSubtype(anyOf = ValidLocationSubtype.LocationSubtype.UN_LOCATION)
     @ValidLocationSubtype(anyOf = ValidLocationSubtype.LocationSubtype.FACILITY)
     private final LocationTO portWithTerminalLocation;
```

Signed-off-by: Niels Thykier <nt@asseco.dk>