### PR TITLE
Preperation for slimming DCSA-Core

### DIFF
--- a/src/main/java/org/dcsa/core/events/model/CargoItem.java
+++ b/src/main/java/org/dcsa/core/events/model/CargoItem.java
@@ -4,7 +4,6 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.dcsa.core.events.model.base.AbstractCargoItem;
-import org.dcsa.core.model.GetId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
@@ -16,7 +15,7 @@ import java.util.UUID;
 @Data
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
-public class CargoItem extends AbstractCargoItem implements GetId<UUID> {
+public class CargoItem extends AbstractCargoItem {
 
   @Id private UUID id;
 

--- a/src/main/java/org/dcsa/core/events/repository/PendingEventRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/PendingEventRepository.java
@@ -2,15 +2,13 @@ package org.dcsa.core.events.repository;
 
 import org.dcsa.core.repository.ExtendedRepository;
 import org.dcsa.core.events.model.PendingMessage;
-import org.dcsa.core.repository.InsertAddonRepository;
 import org.springframework.data.r2dbc.repository.Modifying;
 import org.springframework.data.r2dbc.repository.Query;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
-public interface PendingEventRepository extends ExtendedRepository<PendingMessage, UUID>, InsertAddonRepository<PendingMessage> {
+public interface PendingEventRepository extends ExtendedRepository<PendingMessage, UUID> {
 
     // PostgreSQL specific (due to "FOR UPDATE SKIP LOCKED")
     @Query("DELETE FROM unmapped_event_queue WHERE event_id = ("

--- a/src/main/java/org/dcsa/core/events/service/impl/PendingEventServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/PendingEventServiceImpl.java
@@ -169,7 +169,7 @@ public class PendingEventServiceImpl extends ExtendedBaseServiceImpl<PendingEven
                     }
                     return eventSubscriptionService.update(submissionResult.getEventSubscription())
                             .thenMany(Flux.fromIterable(submissionResult.getPendingMessages()))
-                            .concatMap(pendingEventRepository::insert)
+                            .concatMap(pendingEventRepository::save)
                             .then(Mono.just(submissionResult));
                 });
 


### PR DESCRIPTION
Contains:

1. A left over GetId usage.
2. Update of most repositories to cope with ExtendedRepository becoming a fragment.
3. Update of most services to cope with BaseService (and all of its default methods) being removed.

Note that 2+3 are incomplete and only covers some of the "trivial" cases. There will be a follow up for these.