### PR TITLE
Reduce the use of DCSA-Core in cases where it is not necessary

### DIFF
--- a/src/main/java/org/dcsa/core/events/controller/AbstractEventSubscriptionController.java
+++ b/src/main/java/org/dcsa/core/events/controller/AbstractEventSubscriptionController.java
@@ -1,11 +1,11 @@
 package org.dcsa.core.events.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.dcsa.core.controller.BaseController;
 import org.dcsa.core.events.model.EventSubscription;
 import org.dcsa.core.events.model.base.AbstractEventSubscription;
 import org.dcsa.core.events.model.transferobjects.EventSubscriptionSecretUpdateTO;
 import org.dcsa.core.events.service.EventSubscriptionTOService;
+import org.dcsa.core.exception.ConcreteRequestErrorMessageException;
 import org.dcsa.core.exception.GetException;
 import org.dcsa.core.extendedrequest.ExtendedParameters;
 import org.dcsa.core.extendedrequest.ExtendedRequest;
@@ -26,21 +26,46 @@ import java.util.UUID;
     produces = {MediaType.APPLICATION_JSON_VALUE})
 @RequiredArgsConstructor
 public abstract class AbstractEventSubscriptionController<
-        S extends EventSubscriptionTOService<T>, T extends AbstractEventSubscription>
-    extends BaseController<S, T, UUID> {
+        S extends EventSubscriptionTOService<T>, T extends AbstractEventSubscription> {
 
   private final ExtendedParameters extendedParameters;
 
   private final R2dbcDialect r2dbcDialect;
 
+  protected abstract S getService();
+
   protected ExtendedRequest<EventSubscription> newExtendedRequest() {
     return new ExtendedRequest<>(extendedParameters, r2dbcDialect, EventSubscription.class);
   }
 
-  @Override
-  public String getType() {
-    return "EventSubscription";
+  @GetMapping("{id}")
+  @ResponseStatus(HttpStatus.OK)
+  public Mono<T> findById(@PathVariable UUID id) {
+    return getService().findById(id);
   }
+
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Mono<T> create(@Valid @RequestBody T t) {
+        S s = getService();
+        if (t.getSubscriptionID() != null) {
+            return Mono.error(ConcreteRequestErrorMessageException.invalidParameter("EventSubscription", null,
+                    "Id not allowed when creating a new EventSubscription"));
+        }
+        return s.create(t);
+    }
+
+    @PutMapping("{id}")
+    @ResponseStatus(HttpStatus.OK)
+    public Mono<T> update(@PathVariable UUID id, @Valid @RequestBody T t) {
+        S s = getService();
+        if (!id.equals(t.getSubscriptionID())) {
+            return Mono.error(ConcreteRequestErrorMessageException.invalidParameter("EventSubscription", null,
+                    "Id in url does not match id in body"));
+        }
+        return s.update(t);
+    }
 
   @GetMapping
   public Flux<T> findAll(ServerHttpResponse response, ServerHttpRequest request) {
@@ -68,5 +93,11 @@ public abstract class AbstractEventSubscriptionController<
       @PathVariable UUID id,
       @Valid @RequestBody EventSubscriptionSecretUpdateTO eventSubscriptionSecretUpdateTO) {
     return getService().updateSecret(id, eventSubscriptionSecretUpdateTO);
+  }
+
+  @DeleteMapping("{id}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  public Mono<Void> deleteById(@PathVariable UUID id) {
+    return getService().deleteById(id);
   }
 }

--- a/src/main/java/org/dcsa/core/events/service/AbstractTransportCallTOService.java
+++ b/src/main/java/org/dcsa/core/events/service/AbstractTransportCallTOService.java
@@ -2,7 +2,11 @@ package org.dcsa.core.events.service;
 
 import org.dcsa.core.events.model.transferobjects.TransportCallTO;
 import org.dcsa.core.service.ExtendedBaseService;
+import reactor.core.publisher.Mono;
 
 public interface AbstractTransportCallTOService<T extends TransportCallTO> extends ExtendedBaseService<T, String> {
 
+    Mono<T> findById(String id);
+
+    Mono<T> create(T transportCallTO);
 }

--- a/src/main/java/org/dcsa/core/events/service/AddressService.java
+++ b/src/main/java/org/dcsa/core/events/service/AddressService.java
@@ -6,7 +6,10 @@ import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
-public interface AddressService extends ExtendedBaseService<Address, UUID> {
+public interface AddressService {
     Mono<Address> ensureResolvable(Address address);
+
     Mono<Address> findByIdOrEmpty(UUID id);
+
+    Mono<Address> findById(UUID uuid);
 }

--- a/src/main/java/org/dcsa/core/events/service/CarrierService.java
+++ b/src/main/java/org/dcsa/core/events/service/CarrierService.java
@@ -7,7 +7,7 @@ import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
-public interface CarrierService extends ExtendedBaseService<Carrier, UUID> {
+public interface CarrierService {
 
     Mono<Carrier> findByCode(CarrierCodeListProvider carrierCodeListProvider, String carrierCode);
 }

--- a/src/main/java/org/dcsa/core/events/service/EquipmentEventService.java
+++ b/src/main/java/org/dcsa/core/events/service/EquipmentEventService.java
@@ -4,6 +4,8 @@ import org.dcsa.core.events.model.EquipmentEvent;
 import reactor.core.publisher.Mono;
 
 public interface EquipmentEventService extends EventService<EquipmentEvent> {
+
     Mono<EquipmentEvent> loadRelatedEntities(EquipmentEvent event);
 
+    Mono<EquipmentEvent> create(EquipmentEvent equipmentEvent);
 }

--- a/src/main/java/org/dcsa/core/events/service/EventService.java
+++ b/src/main/java/org/dcsa/core/events/service/EventService.java
@@ -1,9 +1,14 @@
 package org.dcsa.core.events.service;
 
 import org.dcsa.core.events.model.Event;
+import org.dcsa.core.extendedrequest.ExtendedRequest;
 import org.dcsa.core.service.ExtendedBaseService;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
-public interface EventService<T extends Event> extends ExtendedBaseService<T, UUID> {
+public interface EventService<T extends Event> {
+    Mono<T> findById(UUID id);
+    Flux<T> findAllExtended(ExtendedRequest<T> extendedRequest);
 }

--- a/src/main/java/org/dcsa/core/events/service/EventSubscriptionService.java
+++ b/src/main/java/org/dcsa/core/events/service/EventSubscriptionService.java
@@ -4,10 +4,19 @@ import org.dcsa.core.events.model.Event;
 import org.dcsa.core.events.model.EventSubscription;
 import org.dcsa.core.service.ExtendedBaseService;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
 public interface EventSubscriptionService extends ExtendedBaseService<EventSubscription, UUID> {
 
-  Flux<EventSubscription> findSubscriptionsFor(Event event);
+    Mono<EventSubscription> findById(UUID id);
+
+    Mono<EventSubscription> create(EventSubscription eventSubscription);
+
+    Flux<EventSubscription> findSubscriptionsFor(Event event);
+
+    Mono<Void> deleteById(UUID subscriptionID);
+
+    Mono<EventSubscription> update(EventSubscription t);
 }

--- a/src/main/java/org/dcsa/core/events/service/EventSubscriptionTOService.java
+++ b/src/main/java/org/dcsa/core/events/service/EventSubscriptionTOService.java
@@ -4,18 +4,27 @@ import org.dcsa.core.events.model.EventSubscription;
 import org.dcsa.core.events.model.enums.EventType;
 import org.dcsa.core.events.model.transferobjects.EventSubscriptionSecretUpdateTO;
 import org.dcsa.core.extendedrequest.ExtendedRequest;
-import org.dcsa.core.service.BaseService;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.UUID;
 
-public interface EventSubscriptionTOService<T> extends BaseService<T, UUID> {
+public interface EventSubscriptionTOService<T> {
+  Flux<T> findAll();
+
+  Mono<T> findById(UUID id);
+
   Flux<T> findAllExtended(ExtendedRequest<EventSubscription> extendedRequest);
 
   Mono<Void> updateSecret(
       UUID subscriptionID, EventSubscriptionSecretUpdateTO eventSubscriptionSecretUpdateTO);
 
   List<EventType> getAllowedEventTypes();
+
+  Mono<Void> deleteById(UUID id);
+
+  Mono<T> create(T t);
+
+  Mono<T> update(T t);
 }

--- a/src/main/java/org/dcsa/core/events/service/FacilityService.java
+++ b/src/main/java/org/dcsa/core/events/service/FacilityService.java
@@ -8,10 +8,12 @@ import reactor.core.publisher.Mono;
 import java.util.UUID;
 
 public interface FacilityService extends ExtendedBaseService<Facility, UUID> {
+
   Mono<Facility> findByUNLocationCodeAndFacilityCode(
       String unLocationCode,
       FacilityCodeListProvider facilityCodeListProvider,
       String facilityCode);
 
   Mono<Facility> findByIdOrEmpty(UUID id);
+  Mono<Facility> findById(UUID uuid);
 }

--- a/src/main/java/org/dcsa/core/events/service/GenericEventService.java
+++ b/src/main/java/org/dcsa/core/events/service/GenericEventService.java
@@ -9,4 +9,6 @@ import java.util.UUID;
 public interface GenericEventService extends EventService<Event> {
 
     Mono<Event> findByEventTypeAndEventID(EventType eventType, UUID eventID);
+
+    Mono<Event> create(Event event);
 }

--- a/src/main/java/org/dcsa/core/events/service/LocationService.java
+++ b/src/main/java/org/dcsa/core/events/service/LocationService.java
@@ -7,7 +7,7 @@ import reactor.core.publisher.Mono;
 
 import java.util.function.Function;
 
-public interface LocationService extends ExtendedBaseService<Location, String> {
+public interface LocationService {
 
   Mono<LocationTO> ensureResolvable(LocationTO locationTO);
 

--- a/src/main/java/org/dcsa/core/events/service/OperationsEventService.java
+++ b/src/main/java/org/dcsa/core/events/service/OperationsEventService.java
@@ -5,4 +5,6 @@ import reactor.core.publisher.Mono;
 
 public interface OperationsEventService extends EventService<OperationsEvent> {
     Mono<OperationsEvent> loadRelatedEntities(OperationsEvent event);
+
+    Mono<OperationsEvent> create(OperationsEvent operationsEvent);
 }

--- a/src/main/java/org/dcsa/core/events/service/PartyService.java
+++ b/src/main/java/org/dcsa/core/events/service/PartyService.java
@@ -1,14 +1,9 @@
 package org.dcsa.core.events.service;
 
-import org.dcsa.core.events.model.Party;
 import org.dcsa.core.events.model.transferobjects.PartyTO;
-import org.dcsa.core.service.ExtendedBaseService;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-public interface PartyService extends ExtendedBaseService<Party, String> {
-    Flux<Party> findAllById(Iterable<String> ids);
-
+public interface PartyService {
     @Deprecated
     Mono<PartyTO> ensureResolvable(PartyTO partyTO);
     Mono<PartyTO> findTOById(String publisherID);

--- a/src/main/java/org/dcsa/core/events/service/PendingEventService.java
+++ b/src/main/java/org/dcsa/core/events/service/PendingEventService.java
@@ -5,5 +5,5 @@ import org.dcsa.core.events.model.PendingMessage;
 
 import java.util.UUID;
 
-public interface PendingEventService extends ExtendedBaseService<PendingMessage, UUID> {
+public interface PendingEventService {
 }

--- a/src/main/java/org/dcsa/core/events/service/ReferenceService.java
+++ b/src/main/java/org/dcsa/core/events/service/ReferenceService.java
@@ -1,14 +1,12 @@
 package org.dcsa.core.events.service;
 
-import org.dcsa.core.events.model.Reference;
 import org.dcsa.core.events.model.transferobjects.ReferenceTO;
-import org.dcsa.core.service.BaseService;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.UUID;
 
-public interface ReferenceService extends BaseService<Reference, UUID> {
+public interface ReferenceService {
 
   Mono<List<ReferenceTO>> createReferencesByBookingIDAndTOs(
       UUID bookingID, List<ReferenceTO> references);

--- a/src/main/java/org/dcsa/core/events/service/ServiceService.java
+++ b/src/main/java/org/dcsa/core/events/service/ServiceService.java
@@ -6,6 +6,8 @@ import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
-public interface ServiceService extends ExtendedBaseService<Service, UUID>  {
+public interface ServiceService {
     Mono<Service> findByCarrierServiceCode(String carrierServiceCode);
+
+    Mono<Service> create(Service service);
 }

--- a/src/main/java/org/dcsa/core/events/service/ShipmentEventService.java
+++ b/src/main/java/org/dcsa/core/events/service/ShipmentEventService.java
@@ -5,4 +5,6 @@ import reactor.core.publisher.Mono;
 
 public interface ShipmentEventService extends EventService<ShipmentEvent> {
     Mono<ShipmentEvent> loadRelatedEntities(ShipmentEvent event);
+
+    Mono<ShipmentEvent> create(ShipmentEvent shipmentEvent);
 }

--- a/src/main/java/org/dcsa/core/events/service/TimestampDefinitionService.java
+++ b/src/main/java/org/dcsa/core/events/service/TimestampDefinitionService.java
@@ -3,9 +3,12 @@ package org.dcsa.core.events.service;
 import org.dcsa.core.events.model.OperationsEvent;
 import org.dcsa.core.events.model.TimestampDefinition;
 import org.dcsa.core.service.ExtendedBaseService;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface TimestampDefinitionService extends ExtendedBaseService<TimestampDefinition, String> {
 
     Mono<OperationsEvent> markOperationsEventAsTimestamp(OperationsEvent operationsEvent);
+
+    Flux<TimestampDefinition> findAll();
 }

--- a/src/main/java/org/dcsa/core/events/service/TransportCallService.java
+++ b/src/main/java/org/dcsa/core/events/service/TransportCallService.java
@@ -4,16 +4,17 @@ import org.dcsa.core.events.model.Reference;
 import org.dcsa.core.events.model.Seal;
 import org.dcsa.core.events.model.TransportCall;
 import org.dcsa.core.events.model.transferobjects.DocumentReferenceTO;
-import org.dcsa.core.service.BaseService;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
 
-public interface TransportCallService extends BaseService<TransportCall, String> {
+public interface TransportCallService {
 
     Mono<List<DocumentReferenceTO>> findDocumentReferencesForTransportCallID(String transportCallID);
 
     Mono<List<Reference>> findReferencesForTransportCallID(String transportCallID);
 
     Mono<List<Seal>> findSealsForTransportCallIDAndEquipmentReference(String transportCallID, String equipmentReference);
+
+    Mono<TransportCall> create(TransportCall transportCall);
 }

--- a/src/main/java/org/dcsa/core/events/service/TransportEventService.java
+++ b/src/main/java/org/dcsa/core/events/service/TransportEventService.java
@@ -7,4 +7,6 @@ public interface TransportEventService extends EventService<TransportEvent> {
     Mono<TransportEvent> loadRelatedEntities(TransportEvent event);
 
     Mono<TransportEvent> mapTransportCall(TransportEvent transportEvent);
+
+    Mono<TransportEvent> create(TransportEvent transportEvent);
 }

--- a/src/main/java/org/dcsa/core/events/service/VesselService.java
+++ b/src/main/java/org/dcsa/core/events/service/VesselService.java
@@ -8,5 +8,11 @@ import java.util.UUID;
 
 public interface VesselService extends ExtendedBaseService<Vessel, UUID> {
 
+    Mono<Vessel> create(Vessel vessel);
+
+    Mono<Vessel> update(Vessel vessel);
+
     Mono<Vessel> findByVesselIMONumber(String vesselIMONumber);
+
+    Mono<Vessel> findById(UUID vesselID);
 }

--- a/src/main/java/org/dcsa/core/events/service/VoyageService.java
+++ b/src/main/java/org/dcsa/core/events/service/VoyageService.java
@@ -6,6 +6,8 @@ import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
-public interface VoyageService extends ExtendedBaseService<Voyage, UUID> {
+public interface VoyageService {
     Mono<Voyage> findByCarrierVoyageNumberAndServiceID(String carrierVoyageNumber, UUID serviceID);
+
+    Mono<Voyage> create(Voyage importVoyage);
 }

--- a/src/main/java/org/dcsa/core/events/service/impl/AbstractTransportCallTOServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/AbstractTransportCallTOServiceImpl.java
@@ -48,11 +48,6 @@ public abstract class AbstractTransportCallTOServiceImpl<R extends AbstractTrans
     private R2dbcDialect r2dbcDialect;
 
     @Override
-    public Flux<T> findAll() {
-        return findAllExtended(newExtendedRequest());
-    }
-
-    @Override
     public Flux<T> findAllExtended(ExtendedRequest<T> extendedRequest) {
         return getRepository().findAllExtended(extendedRequest);
     }
@@ -193,12 +188,6 @@ public abstract class AbstractTransportCallTOServiceImpl<R extends AbstractTrans
         }
         return carrierMono.flatMap(serviceService::create);
     }
-
-    @Override
-    public String getIdOfEntity(T entity) {
-        return entity.getTransportCallID();
-    }
-
 
     public ExtendedRequest<T> newExtendedRequest() {
         return new ExtendedRequest<>(extendedParameters, r2dbcDialect, getModelClass());

--- a/src/main/java/org/dcsa/core/events/service/impl/AddressServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/AddressServiceImpl.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.dcsa.core.events.model.Address;
 import org.dcsa.core.events.repository.AddressRepository;
 import org.dcsa.core.events.service.AddressService;
-import org.dcsa.core.service.impl.ExtendedBaseServiceImpl;
+import org.dcsa.core.exception.NotFoundException;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
@@ -12,14 +12,8 @@ import java.util.UUID;
 
 @RequiredArgsConstructor
 @Service
-public class AddressServiceImpl extends ExtendedBaseServiceImpl<AddressRepository, Address, UUID>
-    implements AddressService {
+public class AddressServiceImpl implements AddressService {
   private final AddressRepository addressRepository;
-
-  @Override
-  public AddressRepository getRepository() {
-    return addressRepository;
-  }
 
   @Override
   public Mono<Address> ensureResolvable(Address address) {
@@ -30,6 +24,12 @@ public class AddressServiceImpl extends ExtendedBaseServiceImpl<AddressRepositor
   @Override
   public Mono<Address> findByIdOrEmpty(UUID id) {
     return addressRepository.findByIdOrEmpty(id);
+  }
+
+  @Override
+  public Mono<Address> findById(UUID uuid) {
+      return addressRepository.findById(uuid)
+              .switchIfEmpty(Mono.error(new NotFoundException("Address with id " + uuid + " missing")));
   }
 
 }

--- a/src/main/java/org/dcsa/core/events/service/impl/CarrierServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/CarrierServiceImpl.java
@@ -16,14 +16,9 @@ import java.util.function.Function;
 
 @RequiredArgsConstructor
 @Service
-public class CarrierServiceImpl extends ExtendedBaseServiceImpl<CarrierRepository, Carrier, UUID> implements CarrierService {
+public class CarrierServiceImpl implements CarrierService {
 
     private final CarrierRepository carrierRepository;
-
-    @Override
-    public CarrierRepository getRepository() {
-        return carrierRepository;
-    }
 
     @Override
     public Mono<Carrier> findByCode(CarrierCodeListProvider carrierCodeListProvider, String carrierCode) {

--- a/src/main/java/org/dcsa/core/events/service/impl/EquipmentEventServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/EquipmentEventServiceImpl.java
@@ -30,10 +30,9 @@ public class EquipmentEventServiceImpl extends ExtendedBaseServiceImpl<Equipment
         return equipmentEventRepository;
     }
 
-    //Overriding base method here, as it marks empty results as an error, meaning we can't use switchOnEmpty()
     @Override
     public Mono<EquipmentEvent> findById(UUID id) {
-        return getRepository().findById(id);
+        return equipmentEventRepository.findById(id);
     }
 
 
@@ -65,7 +64,7 @@ public class EquipmentEventServiceImpl extends ExtendedBaseServiceImpl<Equipment
 
     @Override
     public Mono<EquipmentEvent> create(EquipmentEvent equipmentEvent) {
-        return super.create(equipmentEvent).flatMap(
+        return equipmentEventRepository.save(equipmentEvent).flatMap(
                 ee -> {
                     UnmappedEvent unmappedEvent = new UnmappedEvent();
                     unmappedEvent.setNewRecord(true);

--- a/src/main/java/org/dcsa/core/events/service/impl/EventSubscriptionServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/EventSubscriptionServiceImpl.java
@@ -11,6 +11,8 @@ import org.dcsa.core.events.model.transferobjects.DocumentReferenceTO;
 import org.dcsa.core.events.repository.*;
 import org.dcsa.core.events.service.EventSubscriptionService;
 import org.dcsa.core.exception.CreateException;
+import org.dcsa.core.exception.DeleteException;
+import org.dcsa.core.exception.GetException;
 import org.dcsa.core.exception.UpdateException;
 import org.dcsa.core.service.impl.ExtendedBaseServiceImpl;
 import org.springframework.stereotype.Service;
@@ -19,24 +21,20 @@ import reactor.core.publisher.Mono;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
 public class EventSubscriptionServiceImpl extends ExtendedBaseServiceImpl<EventSubscriptionRepository, EventSubscription, UUID> implements EventSubscriptionService {
-    private static final List<String> EMPTY_SQL_LIST;
-
-    static {
-        EMPTY_SQL_LIST = new ArrayList<>();
-        // This is not guaranteed to be correct, but it will work "most of the time".
-        EMPTY_SQL_LIST.add("");
-    }
+    // This is not guaranteed to be correct, but it will work "most of the time".
+    private static final List<String> EMPTY_SQL_LIST = List.of("");
 
     private final EventSubscriptionRepository eventSubscriptionRepository;
     private final MessageServiceConfig messageServiceConfig;
     private final TransportCallRepository transportCallRepository;
-    private final ShipmentEventRepository shipmentEventRepository;
     private final VoyageRepository voyageRepository;
     private final ServiceRepository serviceRepository;
     private final TransportDocumentRepository transportDocumentRepository;
@@ -51,7 +49,19 @@ public class EventSubscriptionServiceImpl extends ExtendedBaseServiceImpl<EventS
     }
 
     @Override
-    protected Mono<EventSubscription> preCreateHook(EventSubscription eventSubscription) {
+    public Mono<EventSubscription> findById(UUID id) {
+        return eventSubscriptionRepository.findById(id)
+                .switchIfEmpty(Mono.error(new GetException("No EventSubscription with ID: " + id)));
+    }
+
+    @Override
+    public Mono<Void> deleteById(UUID subscriptionID) {
+        return eventSubscriptionRepository.deleteById(subscriptionID)
+                .switchIfEmpty(Mono.error(new DeleteException("No EventSubscription with ID: " + subscriptionID)));
+    }
+
+    @Override
+    public Mono<EventSubscription> create(EventSubscription eventSubscription) {
         byte[] secret = eventSubscription.getSecret();
         SignatureMethod signatureMethod;
         if (eventSubscription.getSignatureMethod() == null) {
@@ -88,8 +98,9 @@ public class EventSubscriptionServiceImpl extends ExtendedBaseServiceImpl<EventS
     }
 
     @Override
-    protected Mono<EventSubscription> preUpdateHook(EventSubscription original, EventSubscription update) {
-        return checkEventSubscription(update);
+    public Mono<EventSubscription> update(EventSubscription update) {
+        return checkEventSubscription(update)
+                .flatMap(eventSubscriptionRepository::save);
     }
 
     protected Mono<EventSubscription> checkEventSubscription(EventSubscription eventSubscription) {

--- a/src/main/java/org/dcsa/core/events/service/impl/EventSubscriptionTOServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/EventSubscriptionTOServiceImpl.java
@@ -10,7 +10,6 @@ import org.dcsa.core.events.service.EventSubscriptionTOService;
 import org.dcsa.core.exception.CreateException;
 import org.dcsa.core.exception.UpdateException;
 import org.dcsa.core.extendedrequest.ExtendedRequest;
-import org.dcsa.core.service.impl.BaseServiceImpl;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -25,7 +24,7 @@ public abstract class EventSubscriptionTOServiceImpl<
         T extends AbstractEventSubscription,
         S extends EventSubscriptionService,
         R extends EventSubscriptionRepository>
-    extends BaseServiceImpl<T, UUID> implements EventSubscriptionTOService<T> {
+    implements EventSubscriptionTOService<T> {
 
   public static final List<TransportDocumentTypeCode> ALL_TRANSPORT_DOCUMENT_TYPES =
       List.of(TransportDocumentTypeCode.values());
@@ -158,14 +157,11 @@ public abstract class EventSubscriptionTOServiceImpl<
   }
 
   @Override
-  public Flux<T> findAll() {
-    return mapManyD2TO(getService().findAll());
+  public Mono<T> findById(UUID id) {
+    return mapSingleD2TO(findShallowEventSubscriptionById(id));
   }
 
-  @Override
-  public Mono<T> findById(UUID id) {
-    return mapSingleD2TO(getService().findById(id));
-  }
+  protected abstract Mono<EventSubscription> findShallowEventSubscriptionById(UUID id);
 
   @Override
   public Flux<T> findAllExtended(ExtendedRequest<EventSubscription> extendedRequest) {
@@ -187,16 +183,6 @@ public abstract class EventSubscriptionTOServiceImpl<
   @Override
   public Mono<Void> deleteById(UUID id) {
     return getService().deleteById(id);
-  }
-
-  @Override
-  public Mono<Void> delete(T eventSubscriptionTO) {
-    return getService().deleteById(eventSubscriptionTO.getSubscriptionID());
-  }
-
-  @Override
-  public UUID getIdOfEntity(T entity) {
-    return entity.getSubscriptionID();
   }
 
   protected final Function<String, List<EventType>> stringToEventTypeList =

--- a/src/main/java/org/dcsa/core/events/service/impl/FacilityServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/FacilityServiceImpl.java
@@ -7,6 +7,7 @@ import org.dcsa.core.events.repository.FacilityRepository;
 import org.dcsa.core.events.service.FacilityService;
 import org.dcsa.core.exception.ConcreteRequestErrorMessageException;
 import org.dcsa.core.exception.CreateException;
+import org.dcsa.core.exception.NotFoundException;
 import org.dcsa.core.service.impl.ExtendedBaseServiceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.test.web.servlet.result.FlashAttributeResultMatchers;
@@ -70,5 +71,11 @@ public class FacilityServiceImpl extends ExtendedBaseServiceImpl<FacilityReposit
   @Override
   public Mono<Facility> findByIdOrEmpty(UUID id) {
     return facilityRepository.findByIdOrEmpty(id);
+  }
+
+  @Override
+  public Mono<Facility> findById(UUID uuid) {
+    return facilityRepository.findById(uuid)
+             .switchIfEmpty(Mono.error(new NotFoundException("Facility with id " + uuid + " missing")));
   }
 }

--- a/src/main/java/org/dcsa/core/events/service/impl/LocationServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/LocationServiceImpl.java
@@ -10,7 +10,7 @@ import org.dcsa.core.events.repository.LocationRepository;
 import org.dcsa.core.events.service.AddressService;
 import org.dcsa.core.events.service.FacilityService;
 import org.dcsa.core.events.service.LocationService;
-import org.dcsa.core.service.impl.ExtendedBaseServiceImpl;
+import org.dcsa.core.exception.GetException;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
@@ -20,9 +20,7 @@ import java.util.function.Function;
 
 @RequiredArgsConstructor
 @Service
-public class LocationServiceImpl
-    extends ExtendedBaseServiceImpl<LocationRepository, Location, String>
-    implements LocationService {
+public class LocationServiceImpl implements LocationService {
 
   private final FacilityService facilityService;
   private final AddressService addressService;
@@ -31,10 +29,6 @@ public class LocationServiceImpl
 
   private final LocationMapper locationMapper;
 
-  @Override
-  public LocationRepository getRepository() {
-    return locationRepository;
-  }
 
   public Mono<LocationTO> findPaymentLocationByShippingInstructionID(String shippingInstructionID) {
     return locationRepository
@@ -81,7 +75,9 @@ public class LocationServiceImpl
 
   @Override
   public Mono<LocationTO> findTOById(String locationID) {
-    return findById(locationID).flatMap(this::getLocationTO);
+    return locationRepository.findById(locationID)
+            .switchIfEmpty(Mono.error(new GetException("Cannot find location with ID: " + locationID)))
+            .flatMap(this::getLocationTO);
   }
 
   @Override

--- a/src/main/java/org/dcsa/core/events/service/impl/OperationsEventServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/OperationsEventServiceImpl.java
@@ -1,8 +1,10 @@
 package org.dcsa.core.events.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.dcsa.core.events.model.EquipmentEvent;
 import org.dcsa.core.events.model.OperationsEvent;
 import org.dcsa.core.events.model.UnmappedEvent;
+import org.dcsa.core.events.repository.EquipmentEventRepository;
 import org.dcsa.core.events.repository.OperationsEventRepository;
 import org.dcsa.core.events.repository.UnmappedEventRepository;
 import org.dcsa.core.events.service.*;
@@ -28,6 +30,11 @@ public class OperationsEventServiceImpl extends ExtendedBaseServiceImpl<Operatio
     @Override
     public OperationsEventRepository getRepository() {
         return operationsEventRepository;
+    }
+
+    @Override
+    public Mono<OperationsEvent> findById(UUID id) {
+        return operationsEventRepository.findById(id);
     }
 
     @Override
@@ -92,7 +99,7 @@ public class OperationsEventServiceImpl extends ExtendedBaseServiceImpl<Operatio
                   }
                   return Mono.just(oe);
               })
-              .flatMap(super::create)
+              .flatMap(operationsEventRepository::save)
               .flatMap(timestampDefinitionService::markOperationsEventAsTimestamp)
               .flatMap(
                       ope -> {

--- a/src/main/java/org/dcsa/core/events/service/impl/PendingEventServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/PendingEventServiceImpl.java
@@ -10,7 +10,6 @@ import org.dcsa.core.events.repository.PendingEventRepository;
 import org.dcsa.core.events.service.EventSubscriptionService;
 import org.dcsa.core.events.service.GenericEventService;
 import org.dcsa.core.events.service.PendingEventService;
-import org.dcsa.core.service.impl.ExtendedBaseServiceImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
@@ -30,7 +29,7 @@ import java.util.UUID;
 @Slf4j
 @RequiredArgsConstructor
 @Service
-public class PendingEventServiceImpl extends ExtendedBaseServiceImpl<PendingEventRepository, PendingMessage, UUID> implements PendingEventService {
+public class PendingEventServiceImpl implements PendingEventService {
 
     private static final int EVENTS_PER_BATCH_JOB = 10;
     // To make easier to do this with Flux which works on lists/arrays
@@ -57,11 +56,6 @@ public class PendingEventServiceImpl extends ExtendedBaseServiceImpl<PendingEven
 
     @Value("${dcsa.pendingEventService.parallel:4}")
     private int parallel;
-
-    @Override
-    public PendingEventRepository getRepository() {
-        return pendingEventRepository;
-    }
 
     @Scheduled(
             cron = "${dcsa.pendingEventService.backgroundTasks.processUnmappedEventQueue.cronSchedule:45 */1 * * * *}"
@@ -97,7 +91,7 @@ public class PendingEventServiceImpl extends ExtendedBaseServiceImpl<PendingEven
                                                 return Mono.error(e);
                                             }
                                             return Mono.just(pendingMessage);
-                                        }).concatMap(this::create)
+                                        }).concatMap(pendingEventRepository::save)
                                         .count()
                                         .onErrorResume(ex -> {
                                             log.warn("Error processing event ID " + mappedEvent.getEventID(), ex);

--- a/src/main/java/org/dcsa/core/events/service/impl/ReferenceServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/ReferenceServiceImpl.java
@@ -6,7 +6,6 @@ import org.dcsa.core.events.model.transferobjects.ReferenceTO;
 import org.dcsa.core.events.repository.ReferenceRepository;
 import org.dcsa.core.events.service.ReferenceService;
 import org.dcsa.core.exception.CreateException;
-import org.dcsa.core.service.impl.ExtendedBaseServiceImpl;
 import org.dcsa.core.util.MappingUtils;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
@@ -19,9 +18,7 @@ import java.util.function.Function;
 
 @RequiredArgsConstructor
 @Service
-public class ReferenceServiceImpl
-    extends ExtendedBaseServiceImpl<ReferenceRepository, Reference, UUID>
-    implements ReferenceService {
+public class ReferenceServiceImpl implements ReferenceService {
 
   enum ImplementationType {
     BOOKING,
@@ -29,11 +26,6 @@ public class ReferenceServiceImpl
   }
 
   private final ReferenceRepository referenceRepository;
-
-  @Override
-  public ReferenceRepository getRepository() {
-    return this.referenceRepository;
-  }
 
   @Override
   public Mono<List<ReferenceTO>> createReferencesByBookingIDAndTOs(

--- a/src/main/java/org/dcsa/core/events/service/impl/ServiceServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/ServiceServiceImpl.java
@@ -11,18 +11,18 @@ import java.util.UUID;
 
 @RequiredArgsConstructor
 @org.springframework.stereotype.Service
-public class ServiceServiceImpl extends ExtendedBaseServiceImpl<ServiceRepository, Service, UUID> implements ServiceService {
+public class ServiceServiceImpl implements ServiceService {
 
     private final ServiceRepository serviceRepository;
 
     @Override
-    public ServiceRepository getRepository() {
-        return serviceRepository;
+    public Mono<Service> findByCarrierServiceCode(String carrierServiceCode) {
+        return serviceRepository.findByCarrierServiceCode(carrierServiceCode);
     }
 
     @Override
-    public Mono<Service> findByCarrierServiceCode(String carrierServiceCode) {
-        return serviceRepository.findByCarrierServiceCode(carrierServiceCode);
+    public Mono<Service> create(Service service) {
+        return serviceRepository.save(service);
     }
 
 }

--- a/src/main/java/org/dcsa/core/events/service/impl/ShipmentEventServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/ShipmentEventServiceImpl.java
@@ -8,6 +8,7 @@ import org.dcsa.core.events.repository.ReferenceRepository;
 import org.dcsa.core.events.repository.ShipmentEventRepository;
 import org.dcsa.core.events.repository.UnmappedEventRepository;
 import org.dcsa.core.events.service.ShipmentEventService;
+import org.dcsa.core.exception.GetException;
 import org.dcsa.core.service.impl.ExtendedBaseServiceImpl;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
@@ -29,10 +30,9 @@ public class ShipmentEventServiceImpl extends ExtendedBaseServiceImpl<ShipmentEv
         return shipmentEventRepository;
     }
 
-    //Overriding base method here, as it marks empty results as an error, meaning we can't use switchOnEmpty()
     @Override
     public Mono<ShipmentEvent> findById(UUID id) {
-        return getRepository().findById(id);
+        return shipmentEventRepository.findById(id);
     }
 
     @Override
@@ -73,7 +73,7 @@ public class ShipmentEventServiceImpl extends ExtendedBaseServiceImpl<ShipmentEv
 
     @Override
     public Mono<ShipmentEvent> create(ShipmentEvent shipmentEvent) {
-        return super.create(shipmentEvent).flatMap(
+        return shipmentEventRepository.save(shipmentEvent).flatMap(
                 se -> {
                     UnmappedEvent unmappedEvent = new UnmappedEvent();
                     unmappedEvent.setNewRecord(true);

--- a/src/main/java/org/dcsa/core/events/service/impl/TimestampDefinitionServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/TimestampDefinitionServiceImpl.java
@@ -3,14 +3,13 @@ package org.dcsa.core.events.service.impl;
 import lombok.RequiredArgsConstructor;
 import org.dcsa.core.events.model.OperationsEvent;
 import org.dcsa.core.events.model.TimestampDefinition;
-import org.dcsa.core.exception.CreateException;
-import org.dcsa.core.service.impl.ExtendedBaseServiceImpl;
 import org.dcsa.core.events.repository.TimestampDefinitionRepository;
 import org.dcsa.core.events.service.TimestampDefinitionService;
+import org.dcsa.core.exception.CreateException;
+import org.dcsa.core.service.impl.ExtendedBaseServiceImpl;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
-import java.util.UUID;
 
 @RequiredArgsConstructor
 @Service
@@ -44,4 +43,8 @@ public class TimestampDefinitionServiceImpl extends ExtendedBaseServiceImpl<Time
                 .thenReturn(operationsEvent);
     }
 
+    @Override
+    public Flux<TimestampDefinition> findAll() {
+        return timestampDefinitionRepository.findAll();
+    }
 }

--- a/src/main/java/org/dcsa/core/events/service/impl/TransportCallServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/TransportCallServiceImpl.java
@@ -4,13 +4,11 @@ import lombok.RequiredArgsConstructor;
 import org.dcsa.core.events.model.Reference;
 import org.dcsa.core.events.model.Seal;
 import org.dcsa.core.events.model.TransportCall;
-import org.dcsa.core.events.model.TransportEvent;
 import org.dcsa.core.events.model.enums.DocumentReferenceType;
 import org.dcsa.core.events.model.transferobjects.DocumentReferenceTO;
 import org.dcsa.core.events.repository.ReferenceRepository;
 import org.dcsa.core.events.repository.TransportCallRepository;
 import org.dcsa.core.events.service.TransportCallService;
-import org.dcsa.core.service.impl.ExtendedBaseServiceImpl;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -19,14 +17,9 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @Service
-public class TransportCallServiceImpl extends ExtendedBaseServiceImpl<TransportCallRepository, TransportCall, String> implements TransportCallService {
+public class TransportCallServiceImpl implements TransportCallService {
     private final ReferenceRepository referenceRepository;
     private final TransportCallRepository transportCallRepository;
-
-    @Override
-    public TransportCallRepository getRepository() {
-        return transportCallRepository;
-    }
 
     @Override
     public Mono<List<DocumentReferenceTO>> findDocumentReferencesForTransportCallID(String transportCallID) {
@@ -51,6 +44,11 @@ public class TransportCallServiceImpl extends ExtendedBaseServiceImpl<TransportC
     public Mono<List<Seal>> findSealsForTransportCallIDAndEquipmentReference(String transportCallID, String equipmentReference) {
         return transportCallRepository.findSealsForTransportCallIDAndEquipmentReference(transportCallID, equipmentReference)
                 .collectList();
+    }
+
+    @Override
+    public Mono<TransportCall> create(TransportCall transportCall) {
+        return transportCallRepository.save(transportCall);
     }
 
 }

--- a/src/main/java/org/dcsa/core/events/service/impl/TransportEventServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/TransportEventServiceImpl.java
@@ -8,6 +8,7 @@ import org.dcsa.core.events.repository.UnmappedEventRepository;
 import org.dcsa.core.events.service.TransportCallService;
 import org.dcsa.core.events.service.TransportCallTOService;
 import org.dcsa.core.events.service.TransportEventService;
+import org.dcsa.core.exception.GetException;
 import org.dcsa.core.service.impl.ExtendedBaseServiceImpl;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -31,10 +32,9 @@ public class TransportEventServiceImpl extends ExtendedBaseServiceImpl<Transport
         return transportEventRepository;
     }
 
-    //Overriding base method here, as it marks empty results as an error, meaning we can't use switchOnEmpty()
     @Override
     public Mono<TransportEvent> findById(UUID id) {
-        return getRepository().findById(id);
+        return transportEventRepository.findById(id);
     }
 
     @Override
@@ -62,7 +62,7 @@ public class TransportEventServiceImpl extends ExtendedBaseServiceImpl<Transport
 
     @Override
     public Mono<TransportEvent> create(TransportEvent transportEvent) {
-        return super.create(transportEvent).flatMap(
+        return transportEventRepository.save(transportEvent).flatMap(
                 te -> {
                     UnmappedEvent unmappedEvent = new UnmappedEvent();
                     unmappedEvent.setNewRecord(true);

--- a/src/main/java/org/dcsa/core/events/service/impl/VesselServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/VesselServiceImpl.java
@@ -7,7 +7,6 @@ import org.dcsa.core.events.model.enums.CarrierCodeListProvider;
 import org.dcsa.core.events.repository.VesselRepository;
 import org.dcsa.core.events.service.CarrierService;
 import org.dcsa.core.events.service.VesselService;
-import org.dcsa.core.exception.CreateException;
 import org.dcsa.core.exception.NotFoundException;
 import org.dcsa.core.extendedrequest.ExtendedParameters;
 import org.dcsa.core.extendedrequest.ExtendedRequest;
@@ -38,16 +37,20 @@ public class VesselServiceImpl extends ExtendedBaseServiceImpl<VesselRepository,
     public Mono<Vessel> create(Vessel vessel) {
         //  Fails if duplicate key is created.
         // One should check first using findById before creating, return error if key(VesselIMONumber) exists.
-        return preCreateHook(vessel)
-                .flatMap(this::preSaveHook)
+        return findCarrierIfPresent(vessel)
+                .doOnNext(carrier -> vessel.setVesselOperatorCarrierID(carrier.getId()))
+                .doOnNext(vessel::setCarrier)
+                .thenReturn(vessel)
                 .flatMap(vesselRepository::save);
     }
 
     @Override
-    public Mono<Vessel> update(Vessel vessel) {
-        return findById(getIdOfEntity(vessel))
-                .flatMap(current -> this.preUpdateHook(current, vessel))
-                .flatMap(this::save);
+    public Mono<Vessel> update(Vessel update) {
+        return findCarrierIfPresent(update)
+                .doOnNext(carrier -> update.setVesselOperatorCarrierID(carrier.getId()))
+                .doOnNext(update::setCarrier)
+                .thenReturn(update)
+                .flatMap(vesselRepository::save);
     }
 
     @Override
@@ -88,21 +91,6 @@ public class VesselServiceImpl extends ExtendedBaseServiceImpl<VesselRepository,
             return Mono.empty();
         }
         return carrierService.findByCode(carrierCodeListProvider, carrierCode);
-    }
-
-    @Override
-    public Mono<Vessel> preCreateHook(Vessel vessel) {
-        return findCarrierIfPresent(vessel)
-                .doOnNext(carrier -> vessel.setVesselOperatorCarrierID(carrier.getId()))
-                .doOnNext(vessel::setCarrier)
-                .thenReturn(vessel);
-    }
-    @Override
-    public Mono<Vessel> preUpdateHook(Vessel current, Vessel update) {
-        return findCarrierIfPresent(update)
-                .doOnNext(carrier -> update.setVesselOperatorCarrierID(carrier.getId()))
-                .doOnNext(update::setCarrier)
-                .thenReturn(update);
     }
 
     public ExtendedRequest<Vessel> newExtendedRequest() {

--- a/src/main/java/org/dcsa/core/events/service/impl/VoyageServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/VoyageServiceImpl.java
@@ -12,16 +12,16 @@ import java.util.UUID;
 
 @RequiredArgsConstructor
 @Service
-public class VoyageServiceImpl extends ExtendedBaseServiceImpl<VoyageRepository, Voyage, UUID> implements VoyageService {
+public class VoyageServiceImpl implements VoyageService {
 
     private final VoyageRepository voyageRepository;
 
-    @Override
-    public VoyageRepository getRepository() {
-        return voyageRepository;
-    }
-
     public Mono<Voyage> findByCarrierVoyageNumberAndServiceID(String carrierVoyageNumber, UUID serviceID) {
         return voyageRepository.findByCarrierVoyageNumberAndServiceID(carrierVoyageNumber, serviceID);
+    }
+
+    @Override
+    public Mono<Voyage> create(Voyage importVoyage) {
+        return voyageRepository.save(importVoyage);
     }
 }


### PR DESCRIPTION
These commits will enable the removal/scope reduction of:

- `BaseService` (removal)
- `ExtendedBaseService` reduced to `findAllExtended`
- `BaseController` (removal)
- `ExtendedBaseController` reduced a `@GetMapping` for getting all entities

To keep things easier to review, I have excluded the changes to repositories for now as they can come in a separate PR.