### PR TITLE
Clean up most repositories

### DIFF
--- a/src/main/java/org/dcsa/core/events/repository/ActiveReeferSettingsRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/ActiveReeferSettingsRepository.java
@@ -1,11 +1,9 @@
 package org.dcsa.core.events.repository;
 
 import org.dcsa.core.events.model.ActiveReeferSettings;
-import org.dcsa.core.repository.ExtendedRepository;
-import reactor.core.publisher.Mono;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 
 import java.util.UUID;
 
-public interface ActiveReeferSettingsRepository extends ExtendedRepository<ActiveReeferSettings, UUID> {
-    Mono<Void> deleteByShipmentEquipmentID(UUID shipmentEquipmentID);
+public interface ActiveReeferSettingsRepository extends ReactiveCrudRepository<ActiveReeferSettings, UUID> {
 }

--- a/src/main/java/org/dcsa/core/events/repository/AddressRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/AddressRepository.java
@@ -1,13 +1,13 @@
 package org.dcsa.core.events.repository;
 
 import org.dcsa.core.events.model.Address;
-import org.dcsa.core.repository.ExtendedRepository;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import reactor.core.publisher.Mono;
 
 import java.util.Objects;
 import java.util.UUID;
 
-public interface AddressRepository extends ExtendedRepository<Address, UUID> {
+public interface AddressRepository extends ReactiveCrudRepository<Address, UUID> {
 
     Mono<Address> findByNameAndStreetAndStreetNumberAndFloorAndPostalCodeAndCityAndStateRegionAndCountry(
             String name,

--- a/src/main/java/org/dcsa/core/events/repository/CargoItemRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/CargoItemRepository.java
@@ -1,14 +1,14 @@
 package org.dcsa.core.events.repository;
 
 import org.dcsa.core.events.model.CargoItem;
-import org.dcsa.core.repository.ExtendedRepository;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.UUID;
 
-public interface CargoItemRepository extends ExtendedRepository<CargoItem, UUID>, CargoItemCustomRepository {
+public interface CargoItemRepository extends ReactiveCrudRepository<CargoItem, UUID>, CargoItemCustomRepository {
 
     Flux<CargoItem> findAllByShippingInstructionID(String shippingInstructionID);
     Mono<Void> deleteAllByIdIn(List<UUID> cargoItemIDs);

--- a/src/main/java/org/dcsa/core/events/repository/CargoLineItemRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/CargoLineItemRepository.java
@@ -2,13 +2,14 @@ package org.dcsa.core.events.repository;
 
 import org.dcsa.core.events.model.CargoLineItem;
 import org.dcsa.core.repository.ExtendedRepository;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.UUID;
 
-public interface CargoLineItemRepository extends ExtendedRepository<CargoLineItem, UUID> {
+public interface CargoLineItemRepository extends ReactiveCrudRepository<CargoLineItem, UUID> {
 
     Flux<CargoLineItem> findAllByCargoItemID(UUID cargoItemID);
     Mono<Void> deleteByCargoItemID(UUID cargoItemID);

--- a/src/main/java/org/dcsa/core/events/repository/CarrierClauseRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/CarrierClauseRepository.java
@@ -2,11 +2,12 @@ package org.dcsa.core.events.repository;
 
 import org.dcsa.core.events.model.CarrierClause;
 import org.dcsa.core.repository.ExtendedRepository;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
 @Repository
-public interface CarrierClauseRepository extends ExtendedRepository<CarrierClause, UUID> {
+public interface CarrierClauseRepository extends ReactiveCrudRepository<CarrierClause, UUID> {
 }

--- a/src/main/java/org/dcsa/core/events/repository/CarrierRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/CarrierRepository.java
@@ -3,11 +3,12 @@ package org.dcsa.core.events.repository;
 import org.dcsa.core.repository.ExtendedRepository;
 import org.dcsa.core.events.model.Carrier;
 import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
-public interface CarrierRepository extends ExtendedRepository<Carrier, UUID> {
+public interface CarrierRepository extends ReactiveCrudRepository<Carrier, UUID> {
 
     Mono<Carrier> findBySmdgCode(String smdgCode);
     Mono<Carrier> findByNmftaCode(String NmftaCode);

--- a/src/main/java/org/dcsa/core/events/repository/ChargeRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/ChargeRepository.java
@@ -1,13 +1,13 @@
 package org.dcsa.core.events.repository;
 
 import org.dcsa.core.events.model.Charge;
-import org.dcsa.core.repository.ExtendedRepository;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 
 import java.util.UUID;
 
 @Repository
-public interface ChargeRepository extends ExtendedRepository<Charge, String> {
+public interface ChargeRepository extends ReactiveCrudRepository<Charge, String> {
   Flux<Charge> findAllByShipmentID(UUID shipmentID);
 }

--- a/src/main/java/org/dcsa/core/events/repository/CommodityRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/CommodityRepository.java
@@ -2,6 +2,7 @@ package org.dcsa.core.events.repository;
 
 import org.dcsa.core.events.model.Commodity;
 import org.dcsa.core.repository.ExtendedRepository;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -9,7 +10,7 @@ import reactor.core.publisher.Mono;
 import java.util.UUID;
 
 @Repository
-public interface CommodityRepository extends ExtendedRepository<Commodity, UUID> {
+public interface CommodityRepository extends ReactiveCrudRepository<Commodity, UUID> {
   Flux<Commodity> findByBookingID(UUID bookingID);
   Mono<Void> deleteByBookingID(UUID bookingID);
 }

--- a/src/main/java/org/dcsa/core/events/repository/DisplayedAddressRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/DisplayedAddressRepository.java
@@ -1,15 +1,13 @@
 package org.dcsa.core.events.repository;
 
 import org.dcsa.core.events.model.DisplayedAddress;
-import org.dcsa.core.repository.ExtendedRepository;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
 @Repository
-public interface DisplayedAddressRepository extends ExtendedRepository<DisplayedAddress, UUID> {
-  Mono<Void> deleteAllByDocumentPartyID(UUID documentPartyID);
+public interface DisplayedAddressRepository extends ReactiveCrudRepository<DisplayedAddress, UUID> {
   Flux<DisplayedAddress> findByDocumentPartyIDOrderByAddressLineNumber(UUID documentPartyID);
 }

--- a/src/main/java/org/dcsa/core/events/repository/DocumentPartyRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/DocumentPartyRepository.java
@@ -2,6 +2,8 @@ package org.dcsa.core.events.repository;
 
 import org.dcsa.core.events.model.DocumentParty;
 import org.dcsa.core.repository.ExtendedRepository;
+import org.springframework.data.r2dbc.repository.R2dbcRepository;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -9,7 +11,7 @@ import reactor.core.publisher.Mono;
 import java.util.UUID;
 
 @Repository
-public interface DocumentPartyRepository extends ExtendedRepository<DocumentParty, UUID> {
+public interface DocumentPartyRepository extends ReactiveCrudRepository<DocumentParty, UUID> {
   Flux<DocumentParty> findByBookingID(UUID bookingID);
 
   Flux<DocumentParty> findByShippingInstructionID(String shippingInstructionID);

--- a/src/main/java/org/dcsa/core/events/repository/EquipmentEventRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/EquipmentEventRepository.java
@@ -1,16 +1,9 @@
 package org.dcsa.core.events.repository;
 
 import org.dcsa.core.events.model.EquipmentEvent;
-import org.dcsa.core.events.model.enums.EventType;
 import org.dcsa.core.repository.ExtendedRepository;
-import org.springframework.data.r2dbc.repository.Query;
-import org.springframework.data.repository.query.Param;
-import reactor.core.publisher.Flux;
 
 import java.util.UUID;
 
 public interface EquipmentEventRepository extends ExtendedRepository<EquipmentEvent, UUID> {
-
-    @Query("SELECT * FROM equipment_event a WHERE (:eventType IS NULL or a.event_type =:eventType) AND (:equipmentReference IS NULL or a.equipment_reference =:equipmentReference) ")
-    Flux<EquipmentEvent> findAllEquipmentEventsByFilters(@Param("eventType") EventType eventType, String bookingReference, @Param("equipmentReference") String equipmentReference);
 }

--- a/src/main/java/org/dcsa/core/events/repository/EquipmentRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/EquipmentRepository.java
@@ -1,12 +1,11 @@
 package org.dcsa.core.events.repository;
 
 import org.dcsa.core.events.model.Equipment;
-import org.dcsa.core.repository.ExtendedRepository;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Mono;
 
 @Repository
-public interface EquipmentRepository extends ExtendedRepository<Equipment, String> {
-    Mono<Void> deleteAllByEquipmentReference(String equipmentReference);
+public interface EquipmentRepository extends ReactiveCrudRepository<Equipment, String> {
     Mono<Equipment> findByEquipmentReference(String equipmentReference);
 }

--- a/src/main/java/org/dcsa/core/events/repository/LocationRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/LocationRepository.java
@@ -4,13 +4,13 @@ import org.dcsa.core.events.model.Address;
 import org.dcsa.core.events.model.Facility;
 import org.dcsa.core.events.model.Location;
 import org.dcsa.core.events.model.transferobjects.LocationTO;
-import org.dcsa.core.repository.ExtendedRepository;
 import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
-public interface LocationRepository extends ExtendedRepository<Location, String> {
+public interface LocationRepository extends ReactiveCrudRepository<Location, String> {
     @Query("SELECT location.*"
             + "  FROM location"
             + "  JOIN shipping_instruction ON (location.id=shipping_instruction.invoice_payable_at)"

--- a/src/main/java/org/dcsa/core/events/repository/ModeOfTransportRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/ModeOfTransportRepository.java
@@ -4,11 +4,12 @@ import org.dcsa.core.events.model.ModeOfTransport;
 import org.dcsa.core.events.model.enums.DCSATransportType;
 import org.dcsa.core.repository.ExtendedRepository;
 import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Mono;
 
 @Repository
-public interface ModeOfTransportRepository extends ExtendedRepository<ModeOfTransport, String> {
+public interface ModeOfTransportRepository extends ReactiveCrudRepository<ModeOfTransport, String> {
 
   @Query(
       "SELECT mot.* from transport_call tc " +

--- a/src/main/java/org/dcsa/core/events/repository/PartyContactDetailsRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/PartyContactDetailsRepository.java
@@ -2,13 +2,14 @@ package org.dcsa.core.events.repository;
 
 import org.dcsa.core.events.model.PartyContactDetails;
 import org.dcsa.core.repository.ExtendedRepository;
+import org.springframework.data.r2dbc.repository.R2dbcRepository;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 
 import java.util.UUID;
 
 @Repository
-public interface PartyContactDetailsRepository
-    extends ExtendedRepository<PartyContactDetails, UUID> {
+public interface PartyContactDetailsRepository extends ReactiveCrudRepository<PartyContactDetails, UUID> {
   Flux<PartyContactDetails> findByPartyID(String partyID);
 }

--- a/src/main/java/org/dcsa/core/events/repository/PartyIdentifyingCodeRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/PartyIdentifyingCodeRepository.java
@@ -1,16 +1,13 @@
 package org.dcsa.core.events.repository;
 
-import org.dcsa.core.events.model.Carrier;
 import org.dcsa.core.events.model.PartyIdentifyingCode;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
 @Repository
-public interface PartyIdentifyingCodeRepository
-    extends ReactiveCrudRepository<PartyIdentifyingCode, UUID> {
+public interface PartyIdentifyingCodeRepository extends ReactiveCrudRepository<PartyIdentifyingCode, UUID> {
     Flux<PartyIdentifyingCode> findAllByPartyID(String partyID);
 }

--- a/src/main/java/org/dcsa/core/events/repository/PartyRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/PartyRepository.java
@@ -2,11 +2,13 @@ package org.dcsa.core.events.repository;
 
 import org.dcsa.core.events.model.Party;
 import org.dcsa.core.repository.ExtendedRepository;
+import org.springframework.data.r2dbc.repository.R2dbcRepository;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import reactor.core.publisher.Mono;
 
 import java.util.Objects;
 
-public interface PartyRepository extends ExtendedRepository<Party, String> {
+public interface PartyRepository extends ReactiveCrudRepository<Party, String> {
   default Mono<Party> findByIdOrEmpty(String id) {
     if (Objects.isNull(id)) {
       return Mono.empty();

--- a/src/main/java/org/dcsa/core/events/repository/PendingEventRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/PendingEventRepository.java
@@ -1,24 +1,19 @@
 package org.dcsa.core.events.repository;
 
-import org.dcsa.core.repository.ExtendedRepository;
 import org.dcsa.core.events.model.PendingMessage;
-import org.springframework.data.r2dbc.repository.Modifying;
 import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
-public interface PendingEventRepository extends ExtendedRepository<PendingMessage, UUID> {
+public interface PendingEventRepository extends ReactiveCrudRepository<PendingMessage, UUID> {
 
     // PostgreSQL specific (due to "FOR UPDATE SKIP LOCKED")
     @Query("DELETE FROM unmapped_event_queue WHERE event_id = ("
             + "  SELECT event_id FROM unmapped_event_queue FOR UPDATE SKIP LOCKED LIMIT 1"
             + ") RETURNING event_id")
     Mono<UUID> pollUnmappedEventID();
-
-    @Modifying
-    @Query("INSERT INTO unmapped_event_queue (event_id) VALUES (:eventID)")
-    Mono<Void> enqueueUnmappedEventID(UUID eventID);
 
     // PostgreSQL specific (due to "FOR UPDATE SKIP LOCKED")
     @Query("DELETE FROM pending_event_queue WHERE delivery_id = ("

--- a/src/main/java/org/dcsa/core/events/repository/ReferenceRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/ReferenceRepository.java
@@ -3,12 +3,13 @@ package org.dcsa.core.events.repository;
 import org.dcsa.core.events.model.Reference;
 import org.dcsa.core.repository.ExtendedRepository;
 import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
-public interface ReferenceRepository extends ExtendedRepository<Reference, UUID> {
+public interface ReferenceRepository extends ReactiveCrudRepository<Reference, UUID> {
 
   @Query(
       "SELECT reference.* "

--- a/src/main/java/org/dcsa/core/events/repository/RequestedEquipmentRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/RequestedEquipmentRepository.java
@@ -1,7 +1,7 @@
 package org.dcsa.core.events.repository;
 
 import org.dcsa.core.events.model.RequestedEquipment;
-import org.dcsa.core.repository.ExtendedRepository;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -9,7 +9,7 @@ import reactor.core.publisher.Mono;
 import java.util.UUID;
 
 @Repository
-public interface RequestedEquipmentRepository extends ExtendedRepository<RequestedEquipment, UUID> {
+public interface RequestedEquipmentRepository extends ReactiveCrudRepository<RequestedEquipment, UUID> {
   Flux<RequestedEquipment> findByBookingID(UUID bookingID);
   Mono<Void> deleteByBookingID(UUID bookingID);
 }

--- a/src/main/java/org/dcsa/core/events/repository/SealRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/SealRepository.java
@@ -1,13 +1,11 @@
 package org.dcsa.core.events.repository;
 
 import org.dcsa.core.events.model.Seal;
-import org.dcsa.core.repository.ExtendedRepository;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
-public interface SealRepository extends ExtendedRepository<Seal, UUID> {
-    Mono<Void> deleteAllByShipmentEquipmentID(UUID shipmentEquipmentID);
+public interface SealRepository extends ReactiveCrudRepository<Seal, UUID> {
     Flux<Seal> findAllByShipmentEquipmentID(UUID shipmentEquipmentID);
 }

--- a/src/main/java/org/dcsa/core/events/repository/ServiceRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/ServiceRepository.java
@@ -1,8 +1,8 @@
 package org.dcsa.core.events.repository;
 
 import org.dcsa.core.events.model.Service;
-import org.dcsa.core.repository.ExtendedRepository;
 import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -10,7 +10,7 @@ import reactor.core.publisher.Mono;
 import java.util.UUID;
 
 @Repository
-public interface ServiceRepository extends ExtendedRepository<Service, UUID> {
+public interface ServiceRepository extends ReactiveCrudRepository<Service, UUID> {
 
   @Query(
       "SELECT DISTINCT s.carrier_service_code FROM service s "

--- a/src/main/java/org/dcsa/core/events/repository/ShipmentCarrierClausesRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/ShipmentCarrierClausesRepository.java
@@ -2,13 +2,13 @@ package org.dcsa.core.events.repository;
 
 import org.dcsa.core.events.model.ShipmentCarrierClause;
 import org.dcsa.core.repository.ExtendedRepository;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 
 import java.util.UUID;
 
 @Repository
-public interface ShipmentCarrierClausesRepository
-    extends ExtendedRepository<ShipmentCarrierClause, UUID> {
+public interface ShipmentCarrierClausesRepository extends ReactiveCrudRepository<ShipmentCarrierClause, UUID> {
   Flux<ShipmentCarrierClause> findAllByShipmentID(UUID shipmentID);
 }

--- a/src/main/java/org/dcsa/core/events/repository/ShipmentCutOffTimeRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/ShipmentCutOffTimeRepository.java
@@ -1,13 +1,13 @@
 package org.dcsa.core.events.repository;
 
 import org.dcsa.core.events.model.ShipmentCutOffTime;
-import org.dcsa.core.repository.ExtendedRepository;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 
 import java.util.UUID;
 
 @Repository
-public interface ShipmentCutOffTimeRepository extends ExtendedRepository<ShipmentCutOffTime, UUID> {
+public interface ShipmentCutOffTimeRepository extends ReactiveCrudRepository<ShipmentCutOffTime, UUID> {
   Flux<ShipmentCutOffTime> findAllByShipmentID(UUID shipmentID);
 }

--- a/src/main/java/org/dcsa/core/events/repository/ShipmentEquipmentRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/ShipmentEquipmentRepository.java
@@ -3,13 +3,14 @@ package org.dcsa.core.events.repository;
 import org.dcsa.core.events.model.ShipmentEquipment;
 import org.dcsa.core.repository.ExtendedRepository;
 import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.UUID;
 
-public interface ShipmentEquipmentRepository extends ExtendedRepository<ShipmentEquipment, UUID>, ShipmentEquipmentCustomRepository {
+public interface ShipmentEquipmentRepository extends ReactiveCrudRepository<ShipmentEquipment, UUID>, ShipmentEquipmentCustomRepository {
 
   Mono<Void> deleteShipmentEquipmentByShipmentID(UUID shipmentID);
 

--- a/src/main/java/org/dcsa/core/events/repository/ShipmentLocationRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/ShipmentLocationRepository.java
@@ -1,7 +1,7 @@
 package org.dcsa.core.events.repository;
 
 import org.dcsa.core.events.model.ShipmentLocation;
-import org.dcsa.core.repository.ExtendedRepository;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -9,7 +9,7 @@ import reactor.core.publisher.Mono;
 import java.util.UUID;
 
 @Repository
-public interface ShipmentLocationRepository extends ExtendedRepository<ShipmentLocation, UUID> {
+public interface ShipmentLocationRepository extends ReactiveCrudRepository<ShipmentLocation, UUID> {
   Flux<ShipmentLocation> findByBookingID(UUID bookingID);
   Flux<ShipmentLocation> findByShipmentID(UUID shipmentID);
   Mono<Void> deleteByBookingID(UUID bookingID);

--- a/src/main/java/org/dcsa/core/events/repository/ShipmentRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/ShipmentRepository.java
@@ -2,8 +2,8 @@ package org.dcsa.core.events.repository;
 
 import org.dcsa.core.events.model.Shipment;
 import org.dcsa.core.events.model.enums.ShipmentEventTypeCode;
-import org.dcsa.core.repository.ExtendedRepository;
 import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Mono;
 
@@ -11,7 +11,7 @@ import java.util.UUID;
 
 @Repository
 public interface ShipmentRepository
-    extends ExtendedRepository<Shipment, UUID>, ShipmentCustomRepository {
+    extends ReactiveCrudRepository<Shipment, UUID>, ShipmentCustomRepository {
 
   Mono<Shipment> findByCarrierBookingReference(String carrierBookingReference);
 

--- a/src/main/java/org/dcsa/core/events/repository/ShipmentTransportRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/ShipmentTransportRepository.java
@@ -2,13 +2,14 @@ package org.dcsa.core.events.repository;
 
 import org.dcsa.core.events.model.ShipmentTransport;
 import org.dcsa.core.repository.ExtendedRepository;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 
 import java.util.UUID;
 
 @Repository
-public interface ShipmentTransportRepository extends ExtendedRepository<ShipmentTransport, UUID> {
+public interface ShipmentTransportRepository extends ReactiveCrudRepository<ShipmentTransport, UUID> {
 
   Flux<ShipmentTransport> findAllByShipmentID(UUID shipmentId);
 }

--- a/src/main/java/org/dcsa/core/events/repository/TransportDocumentTypeRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/TransportDocumentTypeRepository.java
@@ -3,10 +3,11 @@ package org.dcsa.core.events.repository;
 import org.dcsa.core.events.model.TransportDocumentType;
 import org.dcsa.core.repository.ExtendedRepository;
 import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import reactor.core.publisher.Flux;
 
 public interface TransportDocumentTypeRepository
-    extends ExtendedRepository<TransportDocumentType, String> {
+    extends ReactiveCrudRepository<TransportDocumentType, String> {
 
   @Query(
       "SELECT DISTINCT tdt.transport_document_type_code FROM transport_document_type tdt "

--- a/src/main/java/org/dcsa/core/events/repository/TransportRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/TransportRepository.java
@@ -3,11 +3,12 @@ package org.dcsa.core.events.repository;
 import org.dcsa.core.events.model.Transport;
 import org.dcsa.core.repository.ExtendedRepository;
 import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import reactor.core.publisher.Flux;
 
 import java.util.UUID;
 
-public interface TransportRepository extends ExtendedRepository<Transport, UUID> {
+public interface TransportRepository extends ReactiveCrudRepository<Transport, UUID> {
 
   @Query(
       "SELECT DISTINCT t.vessel_imo_number FROM transport t "

--- a/src/main/java/org/dcsa/core/events/repository/UnmappedEventRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/UnmappedEventRepository.java
@@ -1,10 +1,10 @@
 package org.dcsa.core.events.repository;
 
 import org.dcsa.core.events.model.UnmappedEvent;
-import org.dcsa.core.repository.ExtendedRepository;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.UUID;
 
 @Repository
-public interface UnmappedEventRepository extends ExtendedRepository<UnmappedEvent, UUID> {}
+public interface UnmappedEventRepository extends ReactiveCrudRepository<UnmappedEvent, UUID> {}

--- a/src/main/java/org/dcsa/core/events/repository/ValueAddedServiceRequestRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/ValueAddedServiceRequestRepository.java
@@ -1,7 +1,7 @@
 package org.dcsa.core.events.repository;
 
 import org.dcsa.core.events.model.ValueAddedServiceRequest;
-import org.dcsa.core.repository.ExtendedRepository;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -10,7 +10,7 @@ import java.util.UUID;
 
 @Repository
 public interface ValueAddedServiceRequestRepository
-    extends ExtendedRepository<ValueAddedServiceRequest, UUID> {
+    extends ReactiveCrudRepository<ValueAddedServiceRequest, UUID> {
 
   Flux<ValueAddedServiceRequest> findByBookingID(UUID bookingID);
 

--- a/src/main/java/org/dcsa/core/events/repository/VoyageRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/VoyageRepository.java
@@ -1,15 +1,16 @@
 package org.dcsa.core.events.repository;
 
 import org.dcsa.core.events.model.Voyage;
-import org.dcsa.core.repository.ExtendedRepository;
 import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
 import java.util.UUID;
 
 @Repository
-public interface VoyageRepository extends ExtendedRepository<Voyage, UUID> {
+public interface VoyageRepository extends ReactiveCrudRepository<Voyage, UUID> {
 
   @Query("SELECT DISTINCT v.carrier_voyage_number FROM voyage v " +
           "JOIN transport_call tc " +


### PR DESCRIPTION
Most repositories do not need to be `ExtendedRepositories`. Prune
their extension to a less "involved" repository type.  While I was
through them, I also pruned some now unused methods.

Signed-off-by: Niels Thykier <nt@asseco.dk>