### PR TITLE
Make CarrierService a `QueryService` for UI-Support

### DIFF
--- a/src/main/java/org/dcsa/core/events/repository/CarrierRepository.java
+++ b/src/main/java/org/dcsa/core/events/repository/CarrierRepository.java
@@ -1,14 +1,12 @@
 package org.dcsa.core.events.repository;
 
-import org.dcsa.core.repository.ExtendedRepository;
 import org.dcsa.core.events.model.Carrier;
-import org.springframework.data.r2dbc.repository.Query;
-import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import org.dcsa.core.repository.ExtendedRepository;
 import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
-public interface CarrierRepository extends ReactiveCrudRepository<Carrier, UUID> {
+public interface CarrierRepository extends ExtendedRepository<Carrier, UUID> {
 
     Mono<Carrier> findBySmdgCode(String smdgCode);
     Mono<Carrier> findByNmftaCode(String NmftaCode);

--- a/src/main/java/org/dcsa/core/events/service/CarrierService.java
+++ b/src/main/java/org/dcsa/core/events/service/CarrierService.java
@@ -1,13 +1,13 @@
 package org.dcsa.core.events.service;
 
 import org.dcsa.core.events.model.enums.CarrierCodeListProvider;
-import org.dcsa.core.service.ExtendedBaseService;
 import org.dcsa.core.events.model.Carrier;
+import org.dcsa.core.service.QueryService;
 import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
-public interface CarrierService {
+public interface CarrierService extends QueryService<Carrier, UUID> {
 
     Mono<Carrier> findByCode(CarrierCodeListProvider carrierCodeListProvider, String carrierCode);
 }

--- a/src/main/java/org/dcsa/core/events/service/impl/CarrierServiceImpl.java
+++ b/src/main/java/org/dcsa/core/events/service/impl/CarrierServiceImpl.java
@@ -1,13 +1,15 @@
 package org.dcsa.core.events.service.impl;
 
 import lombok.RequiredArgsConstructor;
-import org.dcsa.core.events.model.enums.CarrierCodeListProvider;
-import org.dcsa.core.exception.CreateException;
-import org.dcsa.core.service.impl.ExtendedBaseServiceImpl;
 import org.dcsa.core.events.model.Carrier;
+import org.dcsa.core.events.model.enums.CarrierCodeListProvider;
 import org.dcsa.core.events.repository.CarrierRepository;
 import org.dcsa.core.events.service.CarrierService;
+import org.dcsa.core.exception.CreateException;
+import org.dcsa.core.extendedrequest.ExtendedRequest;
+import org.dcsa.core.service.impl.QueryServiceImpl;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.Objects;
@@ -16,9 +18,14 @@ import java.util.function.Function;
 
 @RequiredArgsConstructor
 @Service
-public class CarrierServiceImpl implements CarrierService {
+public class CarrierServiceImpl extends QueryServiceImpl<CarrierRepository, Carrier, UUID> implements CarrierService {
 
     private final CarrierRepository carrierRepository;
+
+    @Override
+    protected CarrierRepository getRepository() {
+        return carrierRepository;
+    }
 
     @Override
     public Mono<Carrier> findByCode(CarrierCodeListProvider carrierCodeListProvider, String carrierCode) {


### PR DESCRIPTION
UI-Support (used in the JIT cluster) relies on `CarrierService` being
a `QueryService` (well, `ExtendedBaseService` as it used to be
called).  Restore this so that it is easier to upgrade the UI-Support
component to the next version of DCSA-Event-Core.

Signed-off-by: Niels Thykier <nt@asseco.dk>